### PR TITLE
Add DDPM unit tests

### DIFF
--- a/tests/models/test_ddpm.py
+++ b/tests/models/test_ddpm.py
@@ -1,0 +1,96 @@
+import pytest
+import torch
+from omegaconf import DictConfig, OmegaConf
+
+from icenet_mp.models.ddpm import DDPM, SimpleEncoder2D
+
+
+def _make_ddpm(*, use_autoregressive: bool = True, **kwargs) -> DDPM:  # noqa: ANN003
+    input_spaces = [
+        DictConfig(
+            {
+                "channels": 1,
+                "name": "osisaf-north",
+                "shape": (16, 16),
+            }
+        ),
+        DictConfig(
+            {
+                "channels": 2,
+                "name": "era5",
+                "shape": (8, 8),
+            }
+        ),
+    ]
+    output_space = DictConfig(
+        {
+            "channels": 1,
+            "name": "osisaf-north",
+            "shape": (16, 16),
+        }
+    )
+    return DDPM(
+        hemisphere="north",
+        input_spaces=input_spaces,
+        loss=OmegaConf.create({"_target_": "torch.nn.HuberLoss"}),
+        metrics=[],
+        n_forecast_steps=3,
+        n_history_steps=2,
+        name="ddpm-test",
+        optimizer=DictConfig({}),
+        output_space=output_space,
+        scheduler=DictConfig({}),
+        start_out_channels=4,
+        time_embed_dim=16,
+        timesteps=2,
+        use_autoregressive=use_autoregressive,
+        **kwargs,
+    )
+
+
+class TestSimpleEncoder2D:
+    def test_forward_shape(self) -> None:
+        encoder = SimpleEncoder2D(in_channels=3, out_channels=8)
+        result = encoder(torch.randn(2, 3, 16, 16))
+        assert result.shape == (2, 8, 16, 16)
+
+
+class TestDDPM:
+    @pytest.mark.parametrize(
+        ("use_autoregressive", "expected_output_channels"),
+        [(True, 1), (False, 3)],
+    )
+    def test_output_channels_follow_sampling_mode(
+        self, use_autoregressive: bool, expected_output_channels: int
+    ) -> None:
+        model = _make_ddpm(use_autoregressive=use_autoregressive)
+        assert model.output_channels == expected_output_channels
+
+    def test_prepare_inputs_resizes_and_combines_conditioning(self) -> None:
+        model = _make_ddpm()
+        batch = {
+            "osisaf-north": torch.randn(2, 2, 1, 16, 16),
+            "era5": torch.randn(2, 2, 2, 8, 8),
+        }
+
+        result = model.prepare_inputs(batch)
+
+        assert result.shape == (2, model.cond_channels, 16, 16)
+
+    def test_forward_is_not_supported(self) -> None:
+        model = _make_ddpm()
+        with pytest.raises(NotImplementedError, match="training_step"):
+            model.forward()
+
+    @pytest.mark.parametrize(
+        ("argument", "value", "message"),
+        [
+            ("kernel_size", 0, "Kernel size must be greater than 0"),
+            ("start_out_channels", 0, "Start out channels must be greater than 0"),
+        ],
+    )
+    def test_invalid_unet_arguments_raise(
+        self, argument: str, value: int, message: str
+    ) -> None:
+        with pytest.raises(ValueError, match=message):
+            _make_ddpm(**{argument: value})

--- a/tests/models/test_ddpm.py
+++ b/tests/models/test_ddpm.py
@@ -29,23 +29,24 @@ def _make_ddpm(*, use_autoregressive: bool = True, **kwargs) -> DDPM:  # noqa: A
             "shape": (16, 16),
         }
     )
-    return DDPM(
-        hemisphere="north",
-        input_spaces=input_spaces,
-        loss=OmegaConf.create({"_target_": "torch.nn.HuberLoss"}),
-        metrics=[],
-        n_forecast_steps=3,
-        n_history_steps=2,
-        name="ddpm-test",
-        optimizer=DictConfig({}),
-        output_space=output_space,
-        scheduler=DictConfig({}),
-        start_out_channels=4,
-        time_embed_dim=16,
-        timesteps=2,
-        use_autoregressive=use_autoregressive,
-        **kwargs,
-    )
+    model_kwargs = {
+        "hemisphere": "north",
+        "input_spaces": input_spaces,
+        "loss": OmegaConf.create({"_target_": "torch.nn.HuberLoss"}),
+        "metrics": [],
+        "n_forecast_steps": 3,
+        "n_history_steps": 2,
+        "name": "ddpm-test",
+        "optimizer": DictConfig({}),
+        "output_space": output_space,
+        "scheduler": DictConfig({}),
+        "start_out_channels": 4,
+        "time_embed_dim": 16,
+        "timesteps": 2,
+        "use_autoregressive": use_autoregressive,
+    }
+    model_kwargs.update(kwargs)
+    return DDPM(**model_kwargs)
 
 
 class TestSimpleEncoder2D:

--- a/tests/models/test_ddpm.py
+++ b/tests/models/test_ddpm.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 import torch
 from omegaconf import DictConfig, OmegaConf
@@ -5,7 +7,7 @@ from omegaconf import DictConfig, OmegaConf
 from icenet_mp.models.ddpm import DDPM, SimpleEncoder2D
 
 
-def _make_ddpm(*, use_autoregressive: bool = True, **kwargs) -> DDPM:  # noqa: ANN003
+def _make_ddpm(*, use_autoregressive: bool = True, **kwargs: Any) -> DDPM:
     input_spaces = [
         DictConfig(
             {
@@ -29,7 +31,7 @@ def _make_ddpm(*, use_autoregressive: bool = True, **kwargs) -> DDPM:  # noqa: A
             "shape": (16, 16),
         }
     )
-    model_kwargs = {
+    model_kwargs: dict[str, Any] = {
         "hemisphere": "north",
         "input_spaces": input_spaces,
         "loss": OmegaConf.create({"_target_": "torch.nn.HuberLoss"}),


### PR DESCRIPTION
Fixes #83.

## Summary

Add focused unit coverage for the DDPM implementation and its conditioning encoder.

- verify `SimpleEncoder2D` preserves spatial dimensions and emits the configured channels
- verify autoregressive and parallel DDPM modes configure the expected output-channel count
- verify `prepare_inputs` resizes ERA5 data and combines it with OSISAF conditioning into the expected 64-channel tensor
- verify the model's unsupported `forward` path fails explicitly
- verify invalid UNet kernel size and starting channel counts are rejected

The change is test-only and does not modify DDPM behavior.

## Testing

The new tests are added under `tests/models/test_ddpm.py`. The full repository test suite was not executed locally, so this is opened as a draft for CI validation.