### PR TITLE
Normalize dates before dataset lookup

### DIFF
--- a/icenet_mp/data/single_dataset.py
+++ b/icenet_mp/data/single_dataset.py
@@ -266,6 +266,7 @@ class SingleDataset(Dataset):
                    slice is invalid
 
         """
+        start_date = normalise_date(start_date)
         try:
             idx_global_start = self._date2idx[start_date]
             idx_ds_start, idx_date_start = self._idx2anemoi[idx_global_start]
@@ -327,6 +328,7 @@ class SingleDataset(Dataset):
 
     def to_index(self, date: np.datetime64) -> int:
         """Return the index of a given date in the dataset."""
+        date = normalise_date(date)
         try:
             return self._date2idx[date]
         except KeyError as exc:

--- a/tests/data/test_date_lookup_normalization.py
+++ b/tests/data/test_date_lookup_normalization.py
@@ -8,6 +8,7 @@ from icenet_mp.data.single_dataset import SingleDataset
 def test_date_lookups_normalise_to_noon(
     mock_dataset_non_normalized_times: Path,
 ) -> None:
+    """Confirm that a midnight datetime is normalised during lookup."""
     dataset = SingleDataset(
         name="test_normalized",
         input_files=[mock_dataset_non_normalized_times],

--- a/tests/data/test_date_lookup_normalization.py
+++ b/tests/data/test_date_lookup_normalization.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import numpy as np
+
+from icenet_mp.data.single_dataset import SingleDataset
+
+
+def test_date_lookups_normalise_to_noon(
+    mock_dataset_non_normalized_times: Path,
+) -> None:
+    dataset = SingleDataset(
+        name="test_normalized",
+        input_files=[mock_dataset_non_normalized_times],
+    )
+    midnight = np.datetime64("2020-01-01")
+
+    assert dataset.to_index(midnight) == 0
+    np.testing.assert_array_equal(
+        dataset.get_tchw_slice(midnight, 1),
+        dataset.get_tchw([dataset.dates[0]]),
+    )


### PR DESCRIPTION
Fixes #427.

## Summary

- Normalize dates before `SingleDataset.to_index()` lookups.
- Apply the same normalization to `get_tchw_slice()` start dates.
- Add a regression test covering date-only inputs against dataset dates normalized to noon.

## Why

`SingleDataset.dates` normalizes timestamps to noon, while the lookup methods previously used caller-provided `np.datetime64` values directly. A date-only value such as `2020-01-01` could therefore fail to match the corresponding normalized `2020-01-01T12:00:00` dataset entry.

## Testing

Added a focused regression test covering both `to_index()` and `get_tchw_slice()`.

This branch has also been rebased onto current `main` following the review on #428.