### PR TITLE
Add gradient connectivity smoke test for stacked ConvNormAct blocks

### DIFF
--- a/tests/data/test_single_dataset.py
+++ b/tests/data/test_single_dataset.py
@@ -9,13 +9,6 @@ from icenet_mp.data.single_dataset import SingleDataset
 from icenet_mp.types import DataSpace
 
 
-class MockAnemoiDataset:
-    def __init__(self, channels: int, height: int, width: int) -> None:
-        """A mock Anemoi dataset for testing purposes."""
-        self.shape = (1, channels, height * width)
-        self.field_shape = (height, width)
-
-
 class TestSingleDataset:
     def test_name(self) -> None:
         dataset = SingleDataset(name="test_dataset", input_files=[])

--- a/tests/models/test_piecewise_encode_decode.py
+++ b/tests/models/test_piecewise_encode_decode.py
@@ -71,3 +71,54 @@ class TestPiecewiseEncodeDecode:
         )
         output_ntchw = decoder.rollout(latent_ntchw, None)
         assert torch.equal(input_ntchw, output_ntchw)
+
+    def test_stacked_conv_blocks_propagate_gradients(self) -> None:
+        """Verify the current stacked encoder/decoder conv blocks receive gradients."""
+        torch.manual_seed(0)
+        n_history_steps = 2
+        input_ntchw = torch.randn(2, n_history_steps, 2, 16, 16, requires_grad=True)
+        input_space = DataSpace(name="input", channels=2, shape=(16, 16))
+
+        encoder = PiecewiseEncoder(
+            conv_activation="SiLU",
+            conv_subblocks_initial=3,
+            conv_subblocks_final=3,
+            data_space_in=input_space,
+            latent_space=(4, 4),
+        )
+        decoder = PiecewiseDecoder(
+            conv_activation="SiLU",
+            conv_subblocks_initial=3,
+            conv_subblocks_final=3,
+            data_space_in=encoder.data_space_out,
+            data_space_out=input_space,
+            restrict_range="none",
+            use_final_normalisation=False,
+            use_hann_window=False,
+        )
+
+        latent_ntchw = encoder.rollout(input_ntchw)
+        output_ntchw = decoder.rollout(latent_ntchw, None)
+        output_ntchw.square().mean().backward()
+
+        assert input_ntchw.grad is not None
+        assert torch.isfinite(input_ntchw.grad).all()
+        assert torch.count_nonzero(input_ntchw.grad) > 0
+
+        for component in (encoder, decoder):
+            conv_gradients = [
+                module.weight.grad
+                for module in component.modules()
+                if isinstance(module, torch.nn.Conv2d)
+            ]
+            assert conv_gradients
+            gradient_norms = []
+            for gradient in conv_gradients:
+                assert gradient is not None
+                assert torch.isfinite(gradient).all()
+                assert torch.count_nonzero(gradient) > 0
+                gradient_norms.append(gradient.norm())
+
+            norms = torch.stack(gradient_norms)
+            numerical_floor = torch.finfo(norms.dtype).eps * norms.max()
+            assert norms.min() > numerical_floor

--- a/tests/models/test_piecewise_encode_decode.py
+++ b/tests/models/test_piecewise_encode_decode.py
@@ -8,8 +8,12 @@ from icenet_mp.types import DataSpace
 
 class TestPiecewiseEncodeDecode:
     @pytest.mark.parametrize("test_batch_size", [1, 2, 3])
-    @pytest.mark.parametrize("test_input_chw", [(1, 60, 60), (4, 20, 60)])
-    @pytest.mark.parametrize("test_patch_size", [(2, 2), (4, 2), (5, 3)])
+    @pytest.mark.parametrize(
+        "test_input_chw", [(1, 60, 60), (4, 20, 60)], ids=lambda chw: f"chw={chw}"
+    )
+    @pytest.mark.parametrize(
+        "test_patch_size", [(2, 2), (4, 2), (5, 3)], ids=lambda patch: f"patch={patch}"
+    )
     @pytest.mark.parametrize("test_timesteps", [1, 2, 3])
     def test_forward(
         self,

--- a/tests/models/test_piecewise_encode_decode.py
+++ b/tests/models/test_piecewise_encode_decode.py
@@ -72,8 +72,8 @@ class TestPiecewiseEncodeDecode:
         output_ntchw = decoder.rollout(latent_ntchw, None)
         assert torch.equal(input_ntchw, output_ntchw)
 
-    def test_stacked_conv_blocks_propagate_gradients(self) -> None:
-        """Verify the current stacked encoder/decoder conv blocks receive gradients."""
+    def test_stacked_conv_blocks_have_connected_gradients(self) -> None:
+        """Smoke-test gradient connectivity through stacked encoder/decoder blocks."""
         torch.manual_seed(0)
         n_history_steps = 2
         input_ntchw = torch.randn(2, n_history_steps, 2, 16, 16, requires_grad=True)
@@ -112,13 +112,7 @@ class TestPiecewiseEncodeDecode:
                 if isinstance(module, torch.nn.Conv2d)
             ]
             assert conv_gradients
-            gradient_norms = []
             for gradient in conv_gradients:
                 assert gradient is not None
                 assert torch.isfinite(gradient).all()
                 assert torch.count_nonzero(gradient) > 0
-                gradient_norms.append(gradient.norm())
-
-            norms = torch.stack(gradient_norms)
-            numerical_floor = torch.finfo(norms.dtype).eps * norms.max()
-            assert norms.min() > numerical_floor

--- a/tests/visualisations/test_metadata.py
+++ b/tests/visualisations/test_metadata.py
@@ -1,6 +1,3 @@
-from collections.abc import Mapping, Sequence
-from typing import Any
-
 import pytest
 from omegaconf import DictConfig
 
@@ -147,35 +144,6 @@ def test_extract_variables_by_source_empty_config() -> None:
     assert extract_variables_by_source({}) == {}
     assert extract_variables_by_source({"datasets": {}}) == {}
     assert extract_variables_by_source({"datasets": None}) == {}
-
-
-class MockDataset:
-    """Mock dataset for hemisphere inference tests."""
-
-    def __init__(
-        self,
-        target_name: str | None = None,
-        inputs: Sequence[Any] | None = None,
-        name: str | None = None,
-        config: Mapping[str, Any] | None = None,
-    ) -> None:
-        """Initialise mock dataset with optional attributes for tests."""
-        if target_name:
-            self.target = MockTarget(target_name)
-        else:
-            self.target = None  # type: ignore[assignment]
-        self.inputs = inputs or []
-        self.name = name
-        self.config = config
-        self.dataset_config = config
-
-
-class MockTarget:
-    """Mock target dataset component."""
-
-    def __init__(self, name: str) -> None:
-        """Initialise mock target with a name."""
-        self.name = name
 
 
 def test_build_metadata_returns_dataclass() -> None:


### PR DESCRIPTION
Smoke test for #346.

Exercise the current PiecewiseEncoder/PiecewiseDecoder path with three ConvNormAct subblocks on both sides. Backpropagate through the full pair and verify that the input and every convolution receive finite, non-zero gradients.

This is intentionally a gradient-connectivity smoke test. It does not claim to measure or rule out vanishing-gradient behaviour in deeper or differently normalised networks.