### PR TITLE
Explain evaluation target-group mismatches

### DIFF
--- a/icenet_mp/data/common_data_module.py
+++ b/icenet_mp/data/common_data_module.py
@@ -45,7 +45,13 @@ class CommonDataModule(LightningDataModule):
         # Check prediction target
         self.target_group_name = config["predict"]["target"]["group_name"]
         if self.target_group_name not in self.dataset_groups:
-            msg = f"Could not find prediction target {self.target_group_name}."
+            available_groups = ", ".join(sorted(self.dataset_groups)) or "<none>"
+            msg = (
+                f"Prediction target group {self.target_group_name!r} was not found in "
+                f"the configured datasets. Available groups: {available_groups}. "
+                "When evaluating a checkpoint, ensure the dataset `group_as` matches "
+                "the checkpoint's `predict.target.group_name`."
+            )
             raise ValueError(msg)
         self._target_variables: list[str] = config["predict"]["target"].get(
             "variables", []

--- a/tests/data/test_common_data_module.py
+++ b/tests/data/test_common_data_module.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import Path
 
 import numpy as np
+import pytest
 from omegaconf import DictConfig
 
 from icenet_mp.data.common_data_module import CommonDataModule
@@ -50,6 +51,23 @@ class TestCommonDataModule:
         assert dm.train_periods[0]["start"] is None
         assert dm.train_periods[1]["end"] is None
         assert dm.val_periods[0]["end"] == "2020-03-31"
+
+    def test_missing_target_group_explains_checkpoint_mismatch(
+        self, cfg_common_data_module: DictConfig
+    ) -> None:
+        """A missing evaluation target should explain how to align dataset groups."""
+        available_group = next(
+            iter(cfg_common_data_module["data"]["datasets"].values())
+        )["group_as"]
+        cfg_common_data_module["predict"]["target"]["group_name"] = "missing-target"
+
+        with pytest.raises(ValueError, match="missing-target") as exc_info:
+            CommonDataModule(cfg_common_data_module)
+
+        message = str(exc_info.value)
+        assert str(available_group) in message
+        assert "group_as" in message
+        assert "predict.target.group_name" in message
 
 
 class TestTargetMaskDir:


### PR DESCRIPTION
Closes #171.

Make CommonDataModule report the configured dataset groups when the prediction target is missing, and explain how `group_as` must match `predict.target.group_name` when evaluating a checkpoint.

Add regression coverage for the actionable error message.