### PR TITLE
Add utility module test coverage

### DIFF
--- a/icenet_mp/data/single_dataset.py
+++ b/icenet_mp/data/single_dataset.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Sequence
+from datetime import datetime
 from functools import cached_property
 from pathlib import Path
 from typing import ClassVar, TypeVar, cast
@@ -10,7 +11,6 @@ from anemoi.datasets.usage.dataset import Dataset as AnemoiDataset
 from torch.utils.data import Dataset
 
 from icenet_mp.types import ArrayCHW, ArrayTCHW, DataSpace, Hemisphere
-from icenet_mp.utils import normalise_date
 
 ArrayType = TypeVar("ArrayType", ArrayCHW, ArrayTCHW)
 
@@ -68,10 +68,16 @@ class SingleDataset(Dataset):
         idx2anemoi = {}
         for idx_ds, dataset in enumerate(self.dataslices):
             for idx_date, date in enumerate(dataset.dates):
-                idx_global = self._date2idx.get(normalise_date(date), None)
+                idx_global = self._date2idx.get(self.normalise_date(date), None)
                 if idx_global is not None:
                     idx2anemoi[idx_global] = (idx_ds, idx_date)
         return idx2anemoi
+
+    @staticmethod
+    def normalise_date(np_datetime: np.datetime64) -> np.datetime64:
+        """Normalise a datetime to noon."""
+        dt: datetime = np_datetime.astype("datetime64[ms]").astype(datetime)
+        return np.datetime64(dt.replace(hour=12, minute=0, second=0, microsecond=0))
 
     @staticmethod
     def normalise_date_ranges(
@@ -94,7 +100,7 @@ class SingleDataset(Dataset):
         if len(ranges) <= 1:
             return [dict(date_range) for date_range in ranges]
 
-        #  Assume data always has a daily frequency; for future updates: read from source metadata
+        # Assume data always has a daily frequency; for future updates: read from source metadata
         frequency = np.timedelta64(1, "D")
 
         def _ranges_overlap_or_touch(
@@ -157,7 +163,7 @@ class SingleDataset(Dataset):
         """Return all available dates in the dataset, removing any that are missing."""
         return sorted(
             {
-                normalise_date(date)
+                self.normalise_date(date)
                 for ds in self.dataslices
                 for date in np.delete(ds.dates, list(ds.missing))
             }
@@ -266,7 +272,7 @@ class SingleDataset(Dataset):
                    slice is invalid
 
         """
-        start_date = normalise_date(start_date)
+        start_date = self.normalise_date(start_date)
         try:
             idx_global_start = self._date2idx[start_date]
             idx_ds_start, idx_date_start = self._idx2anemoi[idx_global_start]
@@ -329,7 +335,7 @@ class SingleDataset(Dataset):
 
     def to_index(self, date: np.datetime64) -> int:
         """Return the index of a given date in the dataset."""
-        date = normalise_date(date)
+        date = self.normalise_date(date)
         try:
             return self._date2idx[date]
         except KeyError as exc:

--- a/icenet_mp/utils.py
+++ b/icenet_mp/utils.py
@@ -55,12 +55,6 @@ def mask_dir(base_path: Path, dataset_name: str) -> Path:
     return base_path / "data" / "preprocessing" / "masks" / dataset_name
 
 
-def normalise_date(np_datetime: np.datetime64) -> np.datetime64:
-    """Normalise a datetime to noon."""
-    dt: datetime = np_datetime.astype("datetime64[ms]").astype(datetime)
-    return np.datetime64(dt.replace(hour=12, minute=0, second=0, microsecond=0))
-
-
 def npdatetime_from_datetime(dt: datetime) -> np.datetime64:
     """Convert an aware or naive datetime to numpy datetime64, dropping tzinfo."""
     return np.datetime64(dt.replace(tzinfo=None))

--- a/icenet_mp/utils.py
+++ b/icenet_mp/utils.py
@@ -13,21 +13,6 @@ def datetime_from_npdatetime(dt: np.datetime64) -> datetime:
     return dt.astype("datetime64[ms]").astype(datetime).astimezone(UTC)
 
 
-def npdatetime_from_datetime(dt: datetime) -> np.datetime64:
-    """Convert an aware or naive datetime to numpy datetime64, dropping tzinfo."""
-    return np.datetime64(dt.replace(tzinfo=None))
-
-
-def mask_dir(base_path: Path, dataset_name: str) -> Path:
-    """Path finder for holding the active masks.
-
-    On-disk active mask layout is defined here once and used everywhere, single source,
-    used both when active masks are written (in dataset creation) and when they are read
-    (during model build), so they never diverge.
-    """
-    return base_path / "data" / "preprocessing" / "masks" / dataset_name
-
-
 def get_device_name(accelerator_name: str) -> str:
     """Get the device name for the given accelerator."""
     if accelerator_name == "cuda":
@@ -60,10 +45,25 @@ def get_wandb_run(trainer: Trainer) -> Run | None:
     return None
 
 
+def mask_dir(base_path: Path, dataset_name: str) -> Path:
+    """Path finder for holding the active masks.
+
+    On-disk active mask layout is defined here once and used everywhere, single source,
+    used both when active masks are written (in dataset creation) and when they are read
+    (during model build), so they never diverge.
+    """
+    return base_path / "data" / "preprocessing" / "masks" / dataset_name
+
+
 def normalise_date(np_datetime: np.datetime64) -> np.datetime64:
     """Normalise a datetime to noon."""
     dt: datetime = np_datetime.astype("datetime64[ms]").astype(datetime)
     return np.datetime64(dt.replace(hour=12, minute=0, second=0, microsecond=0))
+
+
+def npdatetime_from_datetime(dt: datetime) -> np.datetime64:
+    """Convert an aware or naive datetime to numpy datetime64, dropping tzinfo."""
+    return np.datetime64(dt.replace(tzinfo=None))
 
 
 def to_list(value: str | list[str]) -> list[str]:

--- a/tests/data/test_single_dataset.py
+++ b/tests/data/test_single_dataset.py
@@ -445,6 +445,12 @@ class TestSingleDataset:
             subset = dataset.subset(variables=["ice_conc"])
             assert subset._normalise is flag
 
+    def test_normalise_date_sets_time_to_noon(self) -> None:
+        """Normalize dates to noon while preserving the calendar date."""
+        result = SingleDataset.normalise_date(np.datetime64("2026-08-21T03:14:15.926"))
+
+        assert result == np.datetime64("2026-08-21T12:00:00.000")
+
     def test_normalise_date_ranges_adjacent_merge(self) -> None:
         """Consecutive ranges (next starts the day after) merge into one span."""
         assert SingleDataset.normalise_date_ranges(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,15 +19,17 @@ from icenet_mp.utils import (
 
 
 def test_datetime_from_npdatetime_returns_utc_datetime() -> None:
+    """Convert NumPy datetimes to timezone-aware UTC datetimes."""
     result = datetime_from_npdatetime(np.datetime64("2026-08-21T12:34:56.789"))
 
     assert result.tzinfo is UTC
     assert result.microsecond == 789000
 
 
-def test_mask_dir_builds_expected_path() -> None:
-    assert mask_dir(Path("/tmp/icenet"), "sic-ssmis") == Path(
-        "/tmp/icenet/data/preprocessing/masks/sic-ssmis"
+def test_mask_dir_builds_expected_path(tmp_path: Path) -> None:
+    """Build the preprocessing mask directory beneath the configured root."""
+    assert mask_dir(tmp_path, "sic-ssmis") == (
+        tmp_path / "data/preprocessing/masks/sic-ssmis"
     )
 
 
@@ -38,10 +40,15 @@ def test_mask_dir_builds_expected_path() -> None:
 def test_get_device_name_for_non_cuda_accelerators(
     accelerator_name: str, expected: str
 ) -> None:
+    """Return readable names for non-CUDA accelerator selections."""
     assert get_device_name(accelerator_name) == expected
 
 
-def test_get_device_name_handles_unavailable_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_device_name_handles_unavailable_cuda(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fall back cleanly when the CUDA device name cannot be queried."""
+
     def _raise_assertion() -> str:
         raise AssertionError
 
@@ -51,16 +58,19 @@ def test_get_device_name_handles_unavailable_cuda(monkeypatch: pytest.MonkeyPatc
 
 
 def test_get_timestamp_has_expected_utc_format() -> None:
+    """Format generated timestamps using the expected UTC pattern."""
     assert re.fullmatch(r"\d{8}_\d{6}", get_timestamp())
 
 
 def test_get_wandb_run_returns_none_without_wandb_logger() -> None:
+    """Return no W&B run when the trainer has no W&B logger."""
     trainer = SimpleNamespace(loggers=[object()])
 
     assert get_wandb_run(trainer) is None  # type: ignore[arg-type]
 
 
 def test_normalise_date_sets_time_to_noon() -> None:
+    """Normalize dates to noon while preserving the calendar date."""
     result = normalise_date(np.datetime64("2026-08-21T03:14:15.926"))
 
     assert result == np.datetime64("2026-08-21T12:00:00.000")
@@ -71,4 +81,5 @@ def test_normalise_date_sets_time_to_noon() -> None:
     [("ice_conc", ["ice_conc"]), (["ice_conc", "2t"], ["ice_conc", "2t"])],
 )
 def test_to_list(value: str | list[str], expected: list[str]) -> None:
+    """Normalize scalar strings and string lists to list form."""
     assert to_list(value) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,12 @@
 import re
 from datetime import UTC
 from pathlib import Path
-from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 import torch
+from lightning import Trainer
 
 from icenet_mp.utils import (
     datetime_from_npdatetime,
@@ -18,68 +19,74 @@ from icenet_mp.utils import (
 )
 
 
-def test_datetime_from_npdatetime_returns_utc_datetime() -> None:
-    """Convert NumPy datetimes to timezone-aware UTC datetimes."""
-    result = datetime_from_npdatetime(np.datetime64("2026-08-21T12:34:56.789"))
+class TestDatetimeFromNpdatetime:
+    def test_returns_utc_datetime(self) -> None:
+        """Convert NumPy datetimes to timezone-aware UTC datetimes."""
+        result = datetime_from_npdatetime(np.datetime64("2026-08-21T12:34:56.789"))
 
-    assert result.tzinfo is UTC
-    assert result.microsecond == 789000
+        assert result.tzinfo is UTC
+        assert result.microsecond == 789000
 
 
-def test_mask_dir_builds_expected_path(tmp_path: Path) -> None:
-    """Build the preprocessing mask directory beneath the configured root."""
-    assert mask_dir(tmp_path, "sic-ssmis") == (
-        tmp_path / "data/preprocessing/masks/sic-ssmis"
+class TestMaskDir:
+    def test_builds_expected_path(self, tmp_path: Path) -> None:
+        """Build the preprocessing mask directory beneath the configured root."""
+        assert mask_dir(tmp_path, "sic-ssmis") == (
+            tmp_path / "data/preprocessing/masks/sic-ssmis"
+        )
+
+
+class TestGetDeviceName:
+    @pytest.mark.parametrize(
+        ("accelerator_name", "expected"),
+        [("cpu", "CPU"), ("mps", "Apple Silicon GPU"), ("auto", "CPU")],
     )
+    def test_for_non_cuda_accelerators(
+        self, accelerator_name: str, expected: str
+    ) -> None:
+        """Return readable names for non-CUDA accelerator selections."""
+        assert get_device_name(accelerator_name) == expected
+
+    def test_handles_unavailable_cuda(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fall back cleanly when the CUDA device name cannot be queried."""
+
+        def _raise_assertion() -> str:
+            raise AssertionError
+
+        monkeypatch.setattr(torch.cuda, "get_device_name", _raise_assertion)
+
+        assert get_device_name("cuda") == "Unknown CUDA device"
 
 
-@pytest.mark.parametrize(
-    ("accelerator_name", "expected"),
-    [("cpu", "CPU"), ("mps", "Apple Silicon GPU"), ("auto", "CPU")],
-)
-def test_get_device_name_for_non_cuda_accelerators(
-    accelerator_name: str, expected: str
-) -> None:
-    """Return readable names for non-CUDA accelerator selections."""
-    assert get_device_name(accelerator_name) == expected
+class TestGetTimestamp:
+    def test_has_expected_utc_format(self) -> None:
+        """Format generated timestamps using the expected UTC pattern."""
+        assert re.fullmatch(r"\d{8}_\d{6}", get_timestamp())
 
 
-def test_get_device_name_handles_unavailable_cuda(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Fall back cleanly when the CUDA device name cannot be queried."""
+class TestGetWandbRun:
+    def test_returns_none_without_wandb_logger(self) -> None:
+        """Return no W&B run when the trainer has no W&B logger."""
+        trainer = MagicMock(spec=Trainer)
+        trainer.loggers = [object()]
 
-    def _raise_assertion() -> str:
-        raise AssertionError
-
-    monkeypatch.setattr(torch.cuda, "get_device_name", _raise_assertion)
-
-    assert get_device_name("cuda") == "Unknown CUDA device"
+        assert get_wandb_run(trainer) is None
 
 
-def test_get_timestamp_has_expected_utc_format() -> None:
-    """Format generated timestamps using the expected UTC pattern."""
-    assert re.fullmatch(r"\d{8}_\d{6}", get_timestamp())
+class TestNormaliseDate:
+    def test_sets_time_to_noon(self) -> None:
+        """Normalize dates to noon while preserving the calendar date."""
+        result = normalise_date(np.datetime64("2026-08-21T03:14:15.926"))
+
+        assert result == np.datetime64("2026-08-21T12:00:00.000")
 
 
-def test_get_wandb_run_returns_none_without_wandb_logger() -> None:
-    """Return no W&B run when the trainer has no W&B logger."""
-    trainer = SimpleNamespace(loggers=[object()])
-
-    assert get_wandb_run(trainer) is None  # type: ignore[arg-type]
-
-
-def test_normalise_date_sets_time_to_noon() -> None:
-    """Normalize dates to noon while preserving the calendar date."""
-    result = normalise_date(np.datetime64("2026-08-21T03:14:15.926"))
-
-    assert result == np.datetime64("2026-08-21T12:00:00.000")
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [("ice_conc", ["ice_conc"]), (["ice_conc", "2t"], ["ice_conc", "2t"])],
-)
-def test_to_list(value: str | list[str], expected: list[str]) -> None:
-    """Normalize scalar strings and string lists to list form."""
-    assert to_list(value) == expected
+class TestToList:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [("ice_conc", ["ice_conc"]), (["ice_conc", "2t"], ["ice_conc", "2t"])],
+        ids=["scalar", "list"],
+    )
+    def test_to_list(self, value: str | list[str], expected: list[str]) -> None:
+        """Normalize scalar strings and string lists to list form."""
+        assert to_list(value) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,7 +17,6 @@ from icenet_mp.utils import (
     get_timestamp,
     get_wandb_run,
     mask_dir,
-    normalise_date,
     to_list,
 )
 
@@ -123,14 +122,6 @@ class TestGetWandbRun:
         trainer.loggers = [wandb_logger]
 
         assert get_wandb_run(trainer) is None
-
-
-class TestNormaliseDate:
-    def test_sets_time_to_noon(self) -> None:
-        """Normalize dates to noon while preserving the calendar date."""
-        result = normalise_date(np.datetime64("2026-08-21T03:14:15.926"))
-
-        assert result == np.datetime64("2026-08-21T12:00:00.000")
 
 
 class TestToList:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,15 @@
 import re
 from datetime import UTC
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 import torch
 from lightning import Trainer
+from lightning.pytorch.loggers import WandbLogger
+from wandb.wandb_run import Run
 
 from icenet_mp.utils import (
     datetime_from_npdatetime,
@@ -47,15 +50,45 @@ class TestGetDeviceName:
         """Return readable names for non-CUDA accelerator selections."""
         assert get_device_name(accelerator_name) == expected
 
-    def test_handles_unavailable_cuda(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Fall back cleanly when the CUDA device name cannot be queried."""
+    @pytest.mark.parametrize(
+        ("accelerator_name", "torch_module"),
+        [("cuda", torch.cuda), ("xpu", torch.xpu)],
+        ids=["cuda", "xpu"],
+    )
+    def test_returns_the_queried_device_name(
+        self,
+        accelerator_name: str,
+        torch_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Return the accelerator's own reported name when the query succeeds."""
+        monkeypatch.setattr(torch_module, "get_device_name", lambda: "Custom GPU")
+
+        assert get_device_name(accelerator_name) == "Custom GPU"
+
+    @pytest.mark.parametrize(
+        ("accelerator_name", "torch_module", "expected"),
+        [
+            ("cuda", torch.cuda, "Unknown CUDA device"),
+            ("xpu", torch.xpu, "Unknown XPU device"),
+        ],
+        ids=["cuda", "xpu"],
+    )
+    def test_handles_unavailable_accelerator(
+        self,
+        accelerator_name: str,
+        torch_module: ModuleType,
+        expected: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Fall back cleanly when the accelerator's device name cannot be queried."""
 
         def _raise_assertion() -> str:
             raise AssertionError
 
-        monkeypatch.setattr(torch.cuda, "get_device_name", _raise_assertion)
+        monkeypatch.setattr(torch_module, "get_device_name", _raise_assertion)
 
-        assert get_device_name("cuda") == "Unknown CUDA device"
+        assert get_device_name(accelerator_name) == expected
 
 
 class TestGetTimestamp:
@@ -69,6 +102,25 @@ class TestGetWandbRun:
         """Return no W&B run when the trainer has no W&B logger."""
         trainer = MagicMock(spec=Trainer)
         trainer.loggers = [object()]
+
+        assert get_wandb_run(trainer) is None
+
+    def test_returns_the_run_from_a_wandb_logger(self) -> None:
+        """Return the active W&B run when a WandbLogger is present."""
+        run = MagicMock(spec=Run)
+        wandb_logger = MagicMock(spec=WandbLogger)
+        wandb_logger.experiment = run
+        trainer = MagicMock(spec=Trainer)
+        trainer.loggers = [wandb_logger]
+
+        assert get_wandb_run(trainer) is run
+
+    def test_returns_none_when_wandb_logger_has_no_run_experiment(self) -> None:
+        """Return None when the WandbLogger's experiment isn't a Run (e.g. offline)."""
+        wandb_logger = MagicMock(spec=WandbLogger)
+        wandb_logger.experiment = None
+        trainer = MagicMock(spec=Trainer)
+        trainer.loggers = [wandb_logger]
 
         assert get_wandb_run(trainer) is None
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import re
-from datetime import UTC
+from datetime import UTC, datetime
 from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock
@@ -17,6 +17,7 @@ from icenet_mp.utils import (
     get_timestamp,
     get_wandb_run,
     mask_dir,
+    npdatetime_from_datetime,
     to_list,
 )
 
@@ -28,6 +29,20 @@ class TestDatetimeFromNpdatetime:
 
         assert result.tzinfo is UTC
         assert result.microsecond == 789000
+
+
+class TestNpdatetimeFromDatetime:
+    def test_converts_naive_datetime(self) -> None:
+        """Convert a naive datetime to numpy datetime64."""
+        result = npdatetime_from_datetime(datetime(2026, 8, 21, 12, 34, 56))
+
+        assert result == np.datetime64("2026-08-21T12:34:56")
+
+    def test_drops_tzinfo_without_shifting_the_wall_clock_time(self) -> None:
+        """Drop tzinfo from an aware datetime without converting to another zone."""
+        result = npdatetime_from_datetime(datetime(2026, 8, 21, 12, 34, 56, tzinfo=UTC))
+
+        assert result == np.datetime64("2026-08-21T12:34:56")
 
 
 class TestMaskDir:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
-from datetime import UTC, datetime
+import re
+from datetime import UTC
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -50,10 +51,7 @@ def test_get_device_name_handles_unavailable_cuda(monkeypatch: pytest.MonkeyPatc
 
 
 def test_get_timestamp_has_expected_utc_format() -> None:
-    timestamp = get_timestamp()
-
-    parsed = datetime.strptime(timestamp, "%Y%m%d_%H%M%S")
-    assert parsed.strftime("%Y%m%d_%H%M%S") == timestamp
+    assert re.fullmatch(r"\d{8}_\d{6}", get_timestamp())
 
 
 def test_get_wandb_run_returns_none_without_wandb_logger() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,76 @@
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from icenet_mp.utils import (
+    datetime_from_npdatetime,
+    get_device_name,
+    get_timestamp,
+    get_wandb_run,
+    mask_dir,
+    normalise_date,
+    to_list,
+)
+
+
+def test_datetime_from_npdatetime_returns_utc_datetime() -> None:
+    result = datetime_from_npdatetime(np.datetime64("2026-08-21T12:34:56.789"))
+
+    assert result.tzinfo is UTC
+    assert result.microsecond == 789000
+
+
+def test_mask_dir_builds_expected_path() -> None:
+    assert mask_dir(Path("/tmp/icenet"), "sic-ssmis") == Path(
+        "/tmp/icenet/data/preprocessing/masks/sic-ssmis"
+    )
+
+
+@pytest.mark.parametrize(
+    ("accelerator_name", "expected"),
+    [("cpu", "CPU"), ("mps", "Apple Silicon GPU"), ("auto", "CPU")],
+)
+def test_get_device_name_for_non_cuda_accelerators(
+    accelerator_name: str, expected: str
+) -> None:
+    assert get_device_name(accelerator_name) == expected
+
+
+def test_get_device_name_handles_unavailable_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_assertion() -> str:
+        raise AssertionError
+
+    monkeypatch.setattr(torch.cuda, "get_device_name", _raise_assertion)
+
+    assert get_device_name("cuda") == "Unknown CUDA device"
+
+
+def test_get_timestamp_has_expected_utc_format() -> None:
+    timestamp = get_timestamp()
+
+    parsed = datetime.strptime(timestamp, "%Y%m%d_%H%M%S")
+    assert parsed.strftime("%Y%m%d_%H%M%S") == timestamp
+
+
+def test_get_wandb_run_returns_none_without_wandb_logger() -> None:
+    trainer = SimpleNamespace(loggers=[object()])
+
+    assert get_wandb_run(trainer) is None  # type: ignore[arg-type]
+
+
+def test_normalise_date_sets_time_to_noon() -> None:
+    result = normalise_date(np.datetime64("2026-08-21T03:14:15.926"))
+
+    assert result == np.datetime64("2026-08-21T12:00:00.000")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("ice_conc", ["ice_conc"]), (["ice_conc", "2t"], ["ice_conc", "2t"])],
+)
+def test_to_list(value: str | list[str], expected: list[str]) -> None:
+    assert to_list(value) == expected


### PR DESCRIPTION
## Summary

Adds focused unit-test coverage for `icenet_mp.utils` as a small contribution toward #62.

## Coverage added

- NumPy datetime to UTC datetime conversion
- mask-directory path construction
- accelerator/device naming and CUDA fallback behaviour
- timestamp formatting
- W&B run lookup fallback
- date normalisation to noon
- string/list normalisation with `to_list`

This PR is test-only and does not change production behaviour.

Part of #62.