### PR TITLE
Add ConvLSTM processor for temporal forecasting

### DIFF
--- a/docs/src/how-to/add-a-model.md
+++ b/docs/src/how-to/add-a-model.md
@@ -44,3 +44,21 @@ You define a latent space `(H_latent, W_latent)` and the framework automatically
 |---|---|
 | **Pros** | Inputs are converted into a common latent space, freeing up the model to learn time evolution. |
 | **Cons** | Latent space representation may lose some spatial correlations present in the inputs. |
+
+### ConvLSTM processor
+
+`ConvLSTMProcessor` keeps the time dimension explicit instead of flattening the history window into channels. It consumes encoded history frames sequentially, maintains spatial hidden and cell states, and then generates forecast frames autoregressively by feeding each prediction back into the recurrent state.
+
+A residual forecast head is enabled by default so the processor learns a latent-space tendency around persistence. Set `residual: false` to predict the next latent frame directly.
+
+```yaml
+processor:
+  _target_: icenet_mp.models.processors.ConvLSTMProcessor
+  hidden_channels: 128
+  kernel_size: 3
+  n_layers: 2
+  dropout: 0.1
+  residual: true
+```
+
+A complete example is available as `model=cnn_convlstm_cnn`.

--- a/icenet_mp/config/model/cnn_convlstm_cnn.yaml
+++ b/icenet_mp/config/model/cnn_convlstm_cnn.yaml
@@ -1,0 +1,50 @@
+_target_: icenet_mp.models.EncodeProcessDecode
+
+name: cnn-convlstm-cnn
+
+encoders:
+  latent_space: [144, 144]
+  era5:
+    _target_: icenet_mp.models.encoders.CNNEncoder
+    kernel_size: 5
+    n_layers: 1
+    scale_factor: 3
+  float-argo:
+    _target_: icenet_mp.models.encoders.CNNEncoder
+    kernel_size: 5
+    n_layers: 1
+    scale_factor: 3
+  sic-icenet:
+    _target_: icenet_mp.models.encoders.CNNEncoder
+    kernel_size: 5
+    n_layers: 1
+    scale_factor: 3
+  sic-osisaf:
+    _target_: icenet_mp.models.encoders.CNNEncoder
+    kernel_size: 5
+    n_layers: 1
+    scale_factor: 3
+  sic-ssmis:
+    _target_: icenet_mp.models.encoders.CNNEncoder
+    kernel_size: 5
+    n_layers: 1
+    scale_factor: 3
+
+processor:
+  _target_: icenet_mp.models.processors.ConvLSTMProcessor
+  hidden_channels: 128
+  kernel_size: 3
+  n_layers: 2
+  dropout: 0.1
+  residual: true
+
+decoder:
+  _target_: icenet_mp.models.decoders.CNNDecoder
+  kernel_size: 5
+  mask_type: active
+  n_layers: 1
+  norm_type: groupnorm
+  restrict_range: sigmoid
+  scale_factor: 3
+  skip_connection:
+    method: none

--- a/icenet_mp/models/processors/__init__.py
+++ b/icenet_mp/models/processors/__init__.py
@@ -1,4 +1,5 @@
 from .base_processor import BaseProcessor
+from .convlstm import ConvLSTMCell, ConvLSTMProcessor
 from .ddpm import DDPMProcessor
 from .gsta import GSTAProcessor
 from .null import NullProcessor
@@ -7,6 +8,8 @@ from .vit import VitProcessor
 
 __all__ = [
     "BaseProcessor",
+    "ConvLSTMCell",
+    "ConvLSTMProcessor",
     "DDPMProcessor",
     "GSTAProcessor",
     "NullProcessor",

--- a/icenet_mp/models/processors/convlstm.py
+++ b/icenet_mp/models/processors/convlstm.py
@@ -1,0 +1,160 @@
+from typing import Any
+
+import torch
+from torch import Tensor, nn
+
+from icenet_mp.types import ProcessorOutput, TensorNTCHW
+
+from .base_processor import BaseProcessor
+
+
+class ConvLSTMCell(nn.Module):
+    """Convolutional LSTM cell for spatial latent-state evolution."""
+
+    def __init__(self, in_channels: int, hidden_channels: int, kernel_size: int) -> None:
+        """Initialise a ConvLSTM cell."""
+        super().__init__()
+        if in_channels <= 0:
+            msg = "in_channels must be greater than 0."
+            raise ValueError(msg)
+        if hidden_channels <= 0:
+            msg = "hidden_channels must be greater than 0."
+            raise ValueError(msg)
+        if kernel_size <= 0 or kernel_size % 2 == 0:
+            msg = "kernel_size must be a positive odd integer."
+            raise ValueError(msg)
+
+        self.hidden_channels = hidden_channels
+        self.gates = nn.Conv2d(
+            in_channels + hidden_channels,
+            4 * hidden_channels,
+            kernel_size=kernel_size,
+            padding=kernel_size // 2,
+        )
+
+    def forward(
+        self, x: Tensor, state: tuple[Tensor, Tensor]
+    ) -> tuple[Tensor, Tensor]:
+        """Advance hidden and cell state by one timestep."""
+        hidden, cell = state
+        input_gate, forget_gate, candidate, output_gate = self.gates(
+            torch.cat((x, hidden), dim=1)
+        ).chunk(4, dim=1)
+
+        input_gate = input_gate.sigmoid()
+        forget_gate = forget_gate.sigmoid()
+        candidate = candidate.tanh()
+        output_gate = output_gate.sigmoid()
+
+        next_cell = forget_gate * cell + input_gate * candidate
+        next_hidden = output_gate * next_cell.tanh()
+        return next_hidden, next_cell
+
+
+class ConvLSTMProcessor(BaseProcessor):
+    """Forecast latent fields using a stacked convolutional LSTM.
+
+    The processor consumes the history sequence one timestep at a time, retaining a
+    spatial hidden/cell state. Forecasts are then produced autoregressively: the most
+    recent prediction is fed back as the next ConvLSTM input. Unlike processors that
+    flatten the history window into channels, this keeps the temporal recurrence
+    explicit while preserving the standard IceNet-MP NTCHW processor contract.
+    """
+
+    def __init__(
+        self,
+        *,
+        hidden_channels: int = 128,
+        kernel_size: int = 3,
+        n_layers: int = 2,
+        dropout: float = 0.0,
+        residual: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        """Initialise a ConvLSTM processor."""
+        super().__init__(**kwargs)
+        if hidden_channels <= 0:
+            msg = "hidden_channels must be greater than 0."
+            raise ValueError(msg)
+        if n_layers <= 0:
+            msg = "n_layers must be greater than 0."
+            raise ValueError(msg)
+        if not 0.0 <= dropout < 1.0:
+            msg = "dropout must be in the range [0, 1)."
+            raise ValueError(msg)
+
+        self.hidden_channels = hidden_channels
+        self.residual = residual
+        self.cells = nn.ModuleList(
+            [
+                ConvLSTMCell(
+                    self.data_space.channels if layer_idx == 0 else hidden_channels,
+                    hidden_channels,
+                    kernel_size,
+                )
+                for layer_idx in range(n_layers)
+            ]
+        )
+        self.dropout = nn.Dropout2d(dropout)
+        self.output_projection = nn.Conv2d(
+            hidden_channels, self.data_space.channels, kernel_size=1
+        )
+
+    def _initial_states(self, x: Tensor) -> list[tuple[Tensor, Tensor]]:
+        """Create zero hidden/cell states matching an input frame."""
+        batch, _, height, width = x.shape
+        return [
+            (
+                x.new_zeros(batch, self.hidden_channels, height, width),
+                x.new_zeros(batch, self.hidden_channels, height, width),
+            )
+            for _ in self.cells
+        ]
+
+    def _step(
+        self, x: Tensor, states: list[tuple[Tensor, Tensor]]
+    ) -> list[tuple[Tensor, Tensor]]:
+        """Advance all recurrent layers by one timestep."""
+        next_states: list[tuple[Tensor, Tensor]] = []
+        layer_input = x
+        for layer_idx, (cell, state) in enumerate(zip(self.cells, states, strict=True)):
+            next_state = cell(layer_input, state)
+            next_states.append(next_state)
+            layer_input = next_state[0]
+            if layer_idx < len(self.cells) - 1:
+                layer_input = self.dropout(layer_input)
+        return next_states
+
+    def rollout(self, x: TensorNTCHW, y: TensorNTCHW | None = None) -> ProcessorOutput:  # noqa: ARG002
+        """Consume history and autoregressively forecast future latent frames."""
+        if x.ndim != 5:
+            msg = f"Expected NTCHW input with 5 dimensions, got shape {tuple(x.shape)}."
+            raise ValueError(msg)
+        if x.shape[1] != self.n_history_steps:
+            msg = (
+                f"Expected {self.n_history_steps} history steps, got {x.shape[1]}."
+            )
+            raise ValueError(msg)
+        if x.shape[2] != self.data_space.channels:
+            msg = (
+                f"Expected {self.data_space.channels} latent channels, got {x.shape[2]}."
+            )
+            raise ValueError(msg)
+
+        current = x[:, 0]
+        states = self._initial_states(current)
+        for time_idx in range(self.n_history_steps):
+            current = x[:, time_idx]
+            states = self._step(current, states)
+
+        predictions: list[Tensor] = []
+        for forecast_idx in range(self.n_forecast_steps):
+            next_frame = self.output_projection(states[-1][0])
+            if self.residual:
+                next_frame = current + next_frame
+            predictions.append(next_frame)
+            current = next_frame
+            if forecast_idx < self.n_forecast_steps - 1:
+                states = self._step(current, states)
+
+        return ProcessorOutput(prediction=torch.stack(predictions, dim=1))

--- a/icenet_mp/models/processors/convlstm.py
+++ b/icenet_mp/models/processors/convlstm.py
@@ -7,11 +7,15 @@ from icenet_mp.types import ProcessorOutput, TensorNTCHW
 
 from .base_processor import BaseProcessor
 
+_NTCHW_NDIM = 5
+
 
 class ConvLSTMCell(nn.Module):
     """Convolutional LSTM cell for spatial latent-state evolution."""
 
-    def __init__(self, in_channels: int, hidden_channels: int, kernel_size: int) -> None:
+    def __init__(
+        self, in_channels: int, hidden_channels: int, kernel_size: int
+    ) -> None:
         """Initialise a ConvLSTM cell."""
         super().__init__()
         if in_channels <= 0:
@@ -32,9 +36,7 @@ class ConvLSTMCell(nn.Module):
             padding=kernel_size // 2,
         )
 
-    def forward(
-        self, x: Tensor, state: tuple[Tensor, Tensor]
-    ) -> tuple[Tensor, Tensor]:
+    def forward(self, x: Tensor, state: tuple[Tensor, Tensor]) -> tuple[Tensor, Tensor]:
         """Advance hidden and cell state by one timestep."""
         hidden, cell = state
         input_gate, forget_gate, candidate, output_gate = self.gates(
@@ -127,18 +129,14 @@ class ConvLSTMProcessor(BaseProcessor):
 
     def rollout(self, x: TensorNTCHW, y: TensorNTCHW | None = None) -> ProcessorOutput:  # noqa: ARG002
         """Consume history and autoregressively forecast future latent frames."""
-        if x.ndim != 5:
+        if x.ndim != _NTCHW_NDIM:
             msg = f"Expected NTCHW input with 5 dimensions, got shape {tuple(x.shape)}."
             raise ValueError(msg)
         if x.shape[1] != self.n_history_steps:
-            msg = (
-                f"Expected {self.n_history_steps} history steps, got {x.shape[1]}."
-            )
+            msg = f"Expected {self.n_history_steps} history steps, got {x.shape[1]}."
             raise ValueError(msg)
         if x.shape[2] != self.data_space.channels:
-            msg = (
-                f"Expected {self.data_space.channels} latent channels, got {x.shape[2]}."
-            )
+            msg = f"Expected {self.data_space.channels} latent channels, got {x.shape[2]}."
             raise ValueError(msg)
 
         current = x[:, 0]

--- a/tests/models/test_convlstm_processor.py
+++ b/tests/models/test_convlstm_processor.py
@@ -1,0 +1,125 @@
+import pytest
+import torch
+
+from icenet_mp.models.processors import ConvLSTMCell, ConvLSTMProcessor
+from icenet_mp.types import DataSpace, ProcessorOutput
+
+
+def test_convlstm_cell_preserves_spatial_shape_and_backpropagates() -> None:
+    cell = ConvLSTMCell(in_channels=3, hidden_channels=5, kernel_size=3)
+    x = torch.randn(2, 3, 8, 10, requires_grad=True)
+    hidden = torch.zeros(2, 5, 8, 10)
+    state = torch.zeros(2, 5, 8, 10)
+
+    next_hidden, next_state = cell(x, (hidden, state))
+
+    assert next_hidden.shape == (2, 5, 8, 10)
+    assert next_state.shape == (2, 5, 8, 10)
+    next_hidden.sum().backward()
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()
+
+
+@pytest.mark.parametrize("n_history_steps", [1, 3])
+@pytest.mark.parametrize("n_forecast_steps", [1, 4])
+def test_convlstm_processor_rollout_shape(
+    n_history_steps: int, n_forecast_steps: int
+) -> None:
+    latent_space = DataSpace(name="latent", channels=4, shape=(8, 8))
+    processor = ConvLSTMProcessor(
+        data_space=latent_space,
+        n_history_steps=n_history_steps,
+        n_forecast_steps=n_forecast_steps,
+        hidden_channels=6,
+        kernel_size=3,
+        n_layers=2,
+        dropout=0.0,
+    )
+    x = torch.randn(2, n_history_steps, 4, 8, 8)
+
+    result = processor.rollout(x)
+
+    assert isinstance(result, ProcessorOutput)
+    assert result.loss is None
+    assert result.prediction.shape == (2, n_forecast_steps, 4, 8, 8)
+
+
+def test_convlstm_processor_backpropagates_through_history() -> None:
+    latent_space = DataSpace(name="latent", channels=2, shape=(6, 6))
+    processor = ConvLSTMProcessor(
+        data_space=latent_space,
+        n_history_steps=3,
+        n_forecast_steps=2,
+        hidden_channels=4,
+        kernel_size=3,
+        n_layers=2,
+        dropout=0.0,
+    )
+    x = torch.randn(2, 3, 2, 6, 6, requires_grad=True)
+
+    processor.rollout(x).prediction.square().mean().backward()
+
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()
+    for name, parameter in processor.named_parameters():
+        assert parameter.grad is not None, f"{name} did not receive a gradient"
+        assert torch.isfinite(parameter.grad).all(), f"{name} has a non-finite gradient"
+
+
+def test_zero_residual_head_reduces_to_persistence() -> None:
+    latent_space = DataSpace(name="latent", channels=2, shape=(5, 5))
+    processor = ConvLSTMProcessor(
+        data_space=latent_space,
+        n_history_steps=3,
+        n_forecast_steps=4,
+        hidden_channels=4,
+        kernel_size=3,
+        n_layers=1,
+        residual=True,
+    )
+    torch.nn.init.zeros_(processor.output_projection.weight)
+    torch.nn.init.zeros_(processor.output_projection.bias)
+    x = torch.randn(1, 3, 2, 5, 5)
+
+    prediction = processor.rollout(x).prediction
+    expected = x[:, -1:].expand_as(prediction)
+
+    torch.testing.assert_close(prediction, expected)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"hidden_channels": 0}, "hidden_channels"),
+        ({"kernel_size": 2}, "kernel_size"),
+        ({"n_layers": 0}, "n_layers"),
+        ({"dropout": -0.1}, "dropout"),
+        ({"dropout": 1.0}, "dropout"),
+    ],
+)
+def test_convlstm_processor_rejects_invalid_configuration(
+    kwargs: dict[str, int | float], message: str
+) -> None:
+    latent_space = DataSpace(name="latent", channels=2, shape=(4, 4))
+    with pytest.raises(ValueError, match=message):
+        ConvLSTMProcessor(
+            data_space=latent_space,
+            n_history_steps=2,
+            n_forecast_steps=2,
+            **kwargs,
+        )
+
+
+def test_convlstm_processor_validates_input_shape() -> None:
+    latent_space = DataSpace(name="latent", channels=2, shape=(4, 4))
+    processor = ConvLSTMProcessor(
+        data_space=latent_space,
+        n_history_steps=2,
+        n_forecast_steps=2,
+        hidden_channels=4,
+    )
+
+    with pytest.raises(ValueError, match="history steps"):
+        processor.rollout(torch.randn(1, 3, 2, 4, 4))
+    with pytest.raises(ValueError, match="latent channels"):
+        processor.rollout(torch.randn(1, 2, 3, 4, 4))

--- a/tests/models/test_convlstm_processor.py
+++ b/tests/models/test_convlstm_processor.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 import torch
 
@@ -6,6 +8,7 @@ from icenet_mp.types import DataSpace, ProcessorOutput
 
 
 def test_convlstm_cell_preserves_spatial_shape_and_backpropagates() -> None:
+    """Verify spatial shape preservation and gradient flow."""
     cell = ConvLSTMCell(in_channels=3, hidden_channels=5, kernel_size=3)
     x = torch.randn(2, 3, 8, 10, requires_grad=True)
     hidden = torch.zeros(2, 5, 8, 10)
@@ -25,6 +28,7 @@ def test_convlstm_cell_preserves_spatial_shape_and_backpropagates() -> None:
 def test_convlstm_processor_rollout_shape(
     n_history_steps: int, n_forecast_steps: int
 ) -> None:
+    """Verify the configured rollout output shape."""
     latent_space = DataSpace(name="latent", channels=4, shape=(8, 8))
     processor = ConvLSTMProcessor(
         data_space=latent_space,
@@ -45,6 +49,7 @@ def test_convlstm_processor_rollout_shape(
 
 
 def test_convlstm_processor_backpropagates_through_history() -> None:
+    """Verify gradients flow through the full input history."""
     latent_space = DataSpace(name="latent", channels=2, shape=(6, 6))
     processor = ConvLSTMProcessor(
         data_space=latent_space,
@@ -67,6 +72,7 @@ def test_convlstm_processor_backpropagates_through_history() -> None:
 
 
 def test_zero_residual_head_reduces_to_persistence() -> None:
+    """Verify a zero residual projection reduces to persistence."""
     latent_space = DataSpace(name="latent", channels=2, shape=(5, 5))
     processor = ConvLSTMProcessor(
         data_space=latent_space,
@@ -78,6 +84,7 @@ def test_zero_residual_head_reduces_to_persistence() -> None:
         residual=True,
     )
     torch.nn.init.zeros_(processor.output_projection.weight)
+    assert processor.output_projection.bias is not None
     torch.nn.init.zeros_(processor.output_projection.bias)
     x = torch.randn(1, 3, 2, 5, 5)
 
@@ -98,8 +105,9 @@ def test_zero_residual_head_reduces_to_persistence() -> None:
     ],
 )
 def test_convlstm_processor_rejects_invalid_configuration(
-    kwargs: dict[str, int | float], message: str
+    kwargs: dict[str, Any], message: str
 ) -> None:
+    """Reject invalid ConvLSTM processor configurations."""
     latent_space = DataSpace(name="latent", channels=2, shape=(4, 4))
     with pytest.raises(ValueError, match=message):
         ConvLSTMProcessor(
@@ -111,6 +119,7 @@ def test_convlstm_processor_rejects_invalid_configuration(
 
 
 def test_convlstm_processor_validates_input_shape() -> None:
+    """Reject invalid history and latent-channel dimensions."""
     latent_space = DataSpace(name="latent", channels=2, shape=(4, 4))
     processor = ConvLSTMProcessor(
         data_space=latent_space,


### PR DESCRIPTION
## Summary

Implements a ConvLSTM processor as an additional temporal forecasting model for IceNet-MP.

## Changes

- add ConvLSTM cell and stacked processor operating directly over NTCHW history sequences
- generate forecast frames autoregressively while preserving spatial recurrent state
- support optional residual latent updates around persistence
- make hidden channels, kernel size, number of layers and dropout configurable
- add a ready-to-run `cnn_convlstm_cnn` model configuration
- add tests for recurrence, shapes, gradients and invalid configuration
- document the processor and configuration

Part of #156.