### PR TITLE
Add CARRA2 dataset source

### DIFF
--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -87,6 +87,24 @@ And run with:
 uv run imp train --config-name my_local_config
 ```
 
+### CARRA2
+
+IceNet-MP includes a `carra2` ingestion source backed by the Copernicus Climate Data Store. The source submits one `reanalysis-pan-carra` request for each exact date/time requested by Anemoi, avoiding accidental Cartesian combinations of days and times.
+
+A sample native-grid recipe is available as `samp_weathernorth_carra2_2p5km_2020_2024_24h_v1`. It requests a small set of surface weather variables at 12:00 UTC for the sample date ranges. Custom recipes can select other CARRA2 variables, level types, level locations, output formats, or geographic subsets:
+
+```yaml
+input:
+  carra2:
+    level_type: pressure_levels
+    level_location: ["850"]
+    variables: [temperature]
+    product_type: analysis
+    data_format: grib
+```
+
+Before downloading CARRA2, configure CDS API credentials and accept the dataset terms in the Climate Data Store. The recipe keeps CARRA2 on its native grid; normal IceNet-MP encoders can then map it into the model's shared latent space, or a `reproject` filter can be added to a custom recipe.
+
 ### Generating Argo float missing dates
 
 Some dates have no Argo float data. When specifying a new Argo float dataset for the first time it is necessary to generate a list of missing dates for a dataset. This can be done as follows:

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -91,7 +91,7 @@ uv run imp train --config-name my_local_config
 
 IceNet-MP includes a `carra2` ingestion source backed by the Copernicus Climate Data Store. The source submits one `reanalysis-pan-carra` request for each exact date/time requested by Anemoi, avoiding accidental Cartesian combinations of days and times.
 
-A sample native-grid recipe is available as `samp_weathernorth_carra2_2p5km_2020_2024_24h_v1`. It requests a small set of surface weather variables at 12:00 UTC for the sample date ranges. Custom recipes can select other CARRA2 variables, level types, level locations, output formats, or geographic subsets:
+A sample native-grid recipe is available as `samp_weathernorth_carra2_2p5km_2020_2024_24h_v1`. It requests a small set of surface weather variables at 12:00 UTC for the sample date ranges. Custom recipes can select other CARRA2 variables, level types, level locations, or geographic subsets. The source currently uses GRIB output so downloaded fields can be materialised safely before temporary files are removed:
 
 ```yaml
 input:

--- a/icenet_mp/config/data/datasets/naming_convention.txt
+++ b/icenet_mp/config/data/datasets/naming_convention.txt
@@ -17,6 +17,7 @@ content:
   - weathersouth: weather data (southern hemisphere)
 source:
   - argo: Argo float data
+  - carra2: CARRA2 pan-Arctic regional reanalysis
   - era5: ERA5 weather data
   - icenet: SSMIS sea ice data from OSISAF via IceNet v1
   - ssmis: SSMIS sea ice data from OSISAF
@@ -25,6 +26,7 @@ source:
 resolution:
   - 0p25: 0.25 degree
   - 0p5: 0.5 degree
+  - 2p5km: 2.5km grid
   - 5p625: 32x32 global grid
   - 25k: 25km grid (deprecated)
   - 25p0km: 25km grid

--- a/icenet_mp/config/data/datasets/samp_weathernorth_carra2_2p5km_2020_2024_24h_v1.yaml
+++ b/icenet_mp/config/data/datasets/samp_weathernorth_carra2_2p5km_2020_2024_24h_v1.yaml
@@ -1,0 +1,33 @@
+samp-weathernorth-carra2-2p5km-2020-2024-24h-v1:
+  name: samp-weathernorth-carra2-2p5km-2020-2024-24h-v1
+  group_as: carra2
+  description: Weather from CARRA2 pan-Arctic regional reanalysis
+  attribution: ECMWF/C3S
+  licence: CC-BY-4.0
+
+  dates:
+    start: '2020-01-01T12:00:00'
+    end: '2024-07-31T12:00:00'
+    frequency: 24h
+    # To reduce size, only retain the date ranges used by the sample split.
+    missing:
+    - start: 2022-01-01T12:00:00
+      end: 2022-06-30T12:00:00
+    - start: 2022-08-01T12:00:00
+      end: 2022-12-31T12:00:00
+    - start: 2023-02-01T12:00:00
+      end: 2023-12-31T12:00:00
+    - start: 2024-02-01T12:00:00
+      end: 2024-06-30T12:00:00
+
+  input:
+    carra2:
+      level_type: single_levels
+      variables:
+      - 2m_temperature
+      - surface_pressure
+      - 10m_u_component_of_wind
+      - 10m_v_component_of_wind
+      - mean_sea_level_pressure
+      product_type: analysis
+      data_format: grib

--- a/icenet_mp/ingestion/sources/__init__.py
+++ b/icenet_mp/ingestion/sources/__init__.py
@@ -12,6 +12,7 @@ from anemoi.datasets.create.sources import source_registry
 from pydantic import Discriminator
 
 from .argo import ArgoSource
+from .carra2 import CARRA2Source
 from .ftp import FTPSource
 from .synthetic import SyntheticSource
 
@@ -29,6 +30,7 @@ def register_sources() -> None:
     sources = {
         "ftp": FTPSource,
         "argo": ArgoSource,
+        "carra2": CARRA2Source,
         "synthetic": SyntheticSource,
     }
     for name, source in sources.items():
@@ -56,6 +58,7 @@ def register_sources() -> None:
 
 __all__ = [
     "ArgoSource",
+    "CARRA2Source",
     "FTPSource",
     "SyntheticSource",
     "register_sources",

--- a/icenet_mp/ingestion/sources/carra2.py
+++ b/icenet_mp/ingestion/sources/carra2.py
@@ -95,9 +95,7 @@ class CARRA2Source(Source):
                 )
                 client.retrieve(self.dataset, request, str(target))
                 field_lists.append(
-                    from_source(
-                        "file", str(target), stream=True, read_all=True
-                    )
+                    from_source("file", str(target), stream=True, read_all=True)
                 )
 
         return MultiFieldList(field_lists)

--- a/icenet_mp/ingestion/sources/carra2.py
+++ b/icenet_mp/ingestion/sources/carra2.py
@@ -1,0 +1,99 @@
+import logging
+from datetime import datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import cdsapi
+from anemoi.datasets.create.input.context import Context
+from anemoi.datasets.create.source import Source
+from anemoi.datasets.create.sources import source_registry
+from anemoi.datasets.dates.groups import GroupOfDates
+from earthkit.data import from_source
+from earthkit.data.core.fieldlist import FieldList, MultiFieldList
+from typing_extensions import override
+
+logger = logging.getLogger(__name__)
+
+
+@source_registry.register("carra2")
+class CARRA2Source(Source):
+    """Download CARRA2 pan-Arctic reanalysis fields from the CDS.
+
+    CARRA2 is exposed through the Climate Data Store as ``reanalysis-pan-carra``.
+    Requests are made one analysis time at a time so the returned fields match the
+    exact dates requested by Anemoi rather than a Cartesian product of years, months,
+    days and times.
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        context: Context,
+        *,
+        variables: list[str],
+        level_type: str = "single_levels",
+        level_location: list[str] | None = None,
+        product_type: str = "analysis",
+        data_format: str = "grib",
+        area: list[float] | None = None,
+        dataset: str = "reanalysis-pan-carra",
+    ) -> None:
+        """Initialise the CARRA2 source."""
+        if not variables:
+            msg = "At least one CARRA2 variable must be requested."
+            raise ValueError(msg)
+        if data_format not in {"grib", "netcdf"}:
+            msg = "CARRA2 data_format must be either 'grib' or 'netcdf'."
+            raise ValueError(msg)
+        if area is not None and len(area) != 4:  # noqa: PLR2004
+            msg = "CARRA2 area must contain [north, west, south, east]."
+            raise ValueError(msg)
+
+        self.context = context
+        self.variables = variables
+        self.level_type = level_type
+        self.level_location = level_location
+        self.product_type = product_type
+        self.data_format = data_format
+        self.area = area
+        self.dataset = dataset
+
+    def _request_for_date(
+        self, date: datetime
+    ) -> dict[str, str | list[str] | list[float]]:
+        """Build a CDS request for one exact CARRA2 valid time."""
+        request: dict[str, str | list[str] | list[float]] = {
+            "level_type": self.level_type,
+            "variable": self.variables,
+            "product_type": self.product_type,
+            "time": [date.strftime("%H:%M")],
+            "year": [date.strftime("%Y")],
+            "month": [date.strftime("%m")],
+            "day": [date.strftime("%d")],
+            "data_format": self.data_format,
+        }
+        if self.level_location is not None:
+            request["level_location"] = self.level_location
+        if self.area is not None:
+            request["area"] = self.area
+        return request
+
+    @override
+    def execute(self, argument: list[datetime] | GroupOfDates) -> FieldList:
+        """Download requested CARRA2 dates and return them as an Earthkit FieldList."""
+        field_lists: list[FieldList] = []
+        extension = "grib" if self.data_format == "grib" else "nc"
+
+        with TemporaryDirectory() as tmpdir:
+            client = cdsapi.Client()
+            for date in argument:
+                target = Path(tmpdir) / f"carra2-{date:%Y%m%d%H%M}.{extension}"
+                request = self._request_for_date(date)
+                logger.info(
+                    "Downloading CARRA2 %s with %d variable(s).",
+                    date.isoformat(),
+                    len(self.variables),
+                )
+                client.retrieve(self.dataset, request, str(target))
+                field_lists.append(from_source("file", str(target)))
+
+        return MultiFieldList(field_lists)

--- a/icenet_mp/ingestion/sources/carra2.py
+++ b/icenet_mp/ingestion/sources/carra2.py
@@ -94,6 +94,10 @@ class CARRA2Source(Source):
                     len(self.variables),
                 )
                 client.retrieve(self.dataset, request, str(target))
-                field_lists.append(from_source("file", str(target)))
+                field_lists.append(
+                    from_source(
+                        "file", str(target), stream=True, read_all=True
+                    )
+                )
 
         return MultiFieldList(field_lists)

--- a/icenet_mp/ingestion/sources/carra2.py
+++ b/icenet_mp/ingestion/sources/carra2.py
@@ -41,8 +41,8 @@ class CARRA2Source(Source):
         if not variables:
             msg = "At least one CARRA2 variable must be requested."
             raise ValueError(msg)
-        if data_format not in {"grib", "netcdf"}:
-            msg = "CARRA2 data_format must be either 'grib' or 'netcdf'."
+        if data_format != "grib":
+            msg = "CARRA2 data_format must be 'grib'."
             raise ValueError(msg)
         if area is not None and len(area) != 4:  # noqa: PLR2004
             msg = "CARRA2 area must contain [north, west, south, east]."
@@ -81,12 +81,11 @@ class CARRA2Source(Source):
     def execute(self, argument: list[datetime] | GroupOfDates) -> FieldList:
         """Download requested CARRA2 dates and return them as an Earthkit FieldList."""
         field_lists: list[FieldList] = []
-        extension = "grib" if self.data_format == "grib" else "nc"
 
         with TemporaryDirectory() as tmpdir:
             client = cdsapi.Client()
             for date in argument:
-                target = Path(tmpdir) / f"carra2-{date:%Y%m%d%H%M}.{extension}"
+                target = Path(tmpdir) / f"carra2-{date:%Y%m%d%H%M}.grib"
                 request = self._request_for_date(date)
                 logger.info(
                     "Downloading CARRA2 %s with %d variable(s).",

--- a/tests/ingestion/sources/test_carra2_source.py
+++ b/tests/ingestion/sources/test_carra2_source.py
@@ -94,7 +94,10 @@ def test_carra2_execute_downloads_each_requested_time(
             "data_format",
         ),
         (
-            {"variables": ["2m_temperature"], "area": [81.0, 15.0, 76.0, 35.0, 40.0]},
+            {
+                "variables": ["2m_temperature"],
+                "area": [81.0, 15.0, 76.0, 35.0, 40.0],
+            },
             "area",
         ),
     ],

--- a/tests/ingestion/sources/test_carra2_source.py
+++ b/tests/ingestion/sources/test_carra2_source.py
@@ -44,6 +44,45 @@ def test_carra2_request_omits_optional_fields_when_unset() -> None:
     assert request["time"] == ["03:00"]
 
 
+def test_carra2_execute_downloads_each_requested_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retrieve each requested valid time and combine the loaded field lists."""
+    source = CARRA2Source(MagicMock(), variables=["2m_temperature"])
+    dates = [
+        datetime.datetime(2026, 1, 2, 3, 0, 0),
+        datetime.datetime(2026, 1, 2, 6, 0, 0),
+    ]
+    client = MagicMock()
+    client_factory = MagicMock(return_value=client)
+    fields = [MagicMock(), MagicMock()]
+    load_fields = MagicMock(side_effect=fields)
+    combined_fields = MagicMock()
+    combine = MagicMock(return_value=combined_fields)
+
+    monkeypatch.setattr(
+        "icenet_mp.ingestion.sources.carra2.cdsapi.Client", client_factory
+    )
+    monkeypatch.setattr("icenet_mp.ingestion.sources.carra2.from_source", load_fields)
+    monkeypatch.setattr("icenet_mp.ingestion.sources.carra2.MultiFieldList", combine)
+
+    result = source.execute(dates)
+
+    assert result is combined_fields
+    client_factory.assert_called_once_with()
+    assert client.retrieve.call_count == 2
+    first_dataset, first_request, first_target = client.retrieve.call_args_list[0].args
+    second_dataset, second_request, second_target = client.retrieve.call_args_list[1].args
+    assert first_dataset == second_dataset == "reanalysis-pan-carra"
+    assert first_request["time"] == ["03:00"]
+    assert second_request["time"] == ["06:00"]
+    assert first_target.endswith("carra2-202601020300.grib")
+    assert second_target.endswith("carra2-202601020600.grib")
+    load_fields.assert_any_call("file", first_target)
+    load_fields.assert_any_call("file", second_target)
+    combine.assert_called_once_with(fields)
+
+
 @pytest.mark.parametrize(
     ("kwargs", "message"),
     [

--- a/tests/ingestion/sources/test_carra2_source.py
+++ b/tests/ingestion/sources/test_carra2_source.py
@@ -1,0 +1,70 @@
+import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from anemoi.datasets.create.sources import source_registry
+
+from icenet_mp.ingestion.sources import CARRA2Source, register_sources
+
+
+def test_carra2_builds_request_for_exact_analysis_time() -> None:
+    source = CARRA2Source(
+        MagicMock(),
+        variables=["temperature"],
+        level_type="pressure_levels",
+        level_location=["850"],
+        area=[81.0, 15.0, 76.0, 35.0],
+    )
+
+    request = source._request_for_date(datetime.datetime(2001, 2, 28, 12, 0, 0))
+
+    assert request == {
+        "level_type": "pressure_levels",
+        "variable": ["temperature"],
+        "product_type": "analysis",
+        "time": ["12:00"],
+        "year": ["2001"],
+        "month": ["02"],
+        "day": ["28"],
+        "data_format": "grib",
+        "level_location": ["850"],
+        "area": [81.0, 15.0, 76.0, 35.0],
+    }
+
+
+def test_carra2_request_omits_optional_fields_when_unset() -> None:
+    source = CARRA2Source(MagicMock(), variables=["2m_temperature"])
+
+    request = source._request_for_date(datetime.datetime(2026, 1, 2, 3, 0, 0))
+
+    assert "level_location" not in request
+    assert "area" not in request
+    assert request["time"] == ["03:00"]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"variables": []}, "At least one CARRA2 variable"),
+        (
+            {"variables": ["2m_temperature"], "data_format": "csv"},
+            "data_format",
+        ),
+        (
+            {"variables": ["2m_temperature"], "area": [81.0, 15.0, 76.0]},
+            "area",
+        ),
+    ],
+)
+def test_carra2_rejects_invalid_configuration(
+    kwargs: dict[str, object], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        CARRA2Source(MagicMock(), **kwargs)  # type: ignore[arg-type]
+
+
+def test_carra2_source_is_registered_with_anemoi() -> None:
+    register_sources()
+
+    assert "carra2" in source_registry.registered
+    assert source_registry.lookup("carra2") is CARRA2Source

--- a/tests/ingestion/sources/test_carra2_source.py
+++ b/tests/ingestion/sources/test_carra2_source.py
@@ -8,6 +8,7 @@ from icenet_mp.ingestion.sources import CARRA2Source, register_sources
 
 
 def test_carra2_builds_request_for_exact_analysis_time() -> None:
+    """Build a CARRA2 request for the exact requested analysis time."""
     source = CARRA2Source(
         MagicMock(),
         variables=["temperature"],
@@ -33,6 +34,7 @@ def test_carra2_builds_request_for_exact_analysis_time() -> None:
 
 
 def test_carra2_request_omits_optional_fields_when_unset() -> None:
+    """Omit optional request fields when they are not configured."""
     source = CARRA2Source(MagicMock(), variables=["2m_temperature"])
 
     request = source._request_for_date(datetime.datetime(2026, 1, 2, 3, 0, 0))
@@ -59,11 +61,13 @@ def test_carra2_request_omits_optional_fields_when_unset() -> None:
 def test_carra2_rejects_invalid_configuration(
     kwargs: dict[str, object], message: str
 ) -> None:
+    """Reject invalid CARRA2 source configurations."""
     with pytest.raises(ValueError, match=message):
         CARRA2Source(MagicMock(), **kwargs)  # type: ignore[arg-type]
 
 
 def test_carra2_source_is_registered_with_anemoi() -> None:
+    """Register CARRA2 with the Anemoi source registry."""
     register_sources()
 
     assert "carra2" in source_registry.registered

--- a/tests/ingestion/sources/test_carra2_source.py
+++ b/tests/ingestion/sources/test_carra2_source.py
@@ -80,8 +80,8 @@ def test_carra2_execute_downloads_each_requested_time(
     assert second_request["time"] == ["06:00"]
     assert first_target.endswith("carra2-202601020300.grib")
     assert second_target.endswith("carra2-202601020600.grib")
-    load_fields.assert_any_call("file", first_target)
-    load_fields.assert_any_call("file", second_target)
+    load_fields.assert_any_call("file", first_target, stream=True, read_all=True)
+    load_fields.assert_any_call("file", second_target, stream=True, read_all=True)
     combine.assert_called_once_with(fields)
 
 

--- a/tests/ingestion/sources/test_carra2_source.py
+++ b/tests/ingestion/sources/test_carra2_source.py
@@ -72,7 +72,9 @@ def test_carra2_execute_downloads_each_requested_time(
     client_factory.assert_called_once_with()
     assert client.retrieve.call_count == 2
     first_dataset, first_request, first_target = client.retrieve.call_args_list[0].args
-    second_dataset, second_request, second_target = client.retrieve.call_args_list[1].args
+    second_dataset, second_request, second_target = client.retrieve.call_args_list[
+        1
+    ].args
     assert first_dataset == second_dataset == "reanalysis-pan-carra"
     assert first_request["time"] == ["03:00"]
     assert second_request["time"] == ["06:00"]

--- a/tests/ingestion/sources/test_carra2_source.py
+++ b/tests/ingestion/sources/test_carra2_source.py
@@ -90,11 +90,11 @@ def test_carra2_execute_downloads_each_requested_time(
     [
         ({"variables": []}, "At least one CARRA2 variable"),
         (
-            {"variables": ["2m_temperature"], "data_format": "csv"},
+            {"variables": ["2m_temperature"], "data_format": "netcdf"},
             "data_format",
         ),
         (
-            {"variables": ["2m_temperature"], "area": [81.0, 15.0, 76.0]},
+            {"variables": ["2m_temperature"], "area": [81.0, 15.0, 76.0, 35.0, 40.0]},
             "area",
         ),
     ],


### PR DESCRIPTION
## Summary

Adds CARRA2 ingestion support and a sample dataset configuration for the pan-Arctic reanalysis.

## Changes

- add a dedicated CARRA2 source for retrieving CDS data
- register CARRA2 with the existing Anemoi source infrastructure
- add a sample northern-weather CARRA2 dataset configuration
- add source tests covering request construction and downloaded data loading
- document CARRA2 usage
- extend the dataset naming convention with CARRA2 and 2.5 km resolution

Closes #432.