### PR TITLE
Add ActivationSaver callback test coverage

### DIFF
--- a/tests/callbacks/test_activation_saver.py
+++ b/tests/callbacks/test_activation_saver.py
@@ -1,8 +1,10 @@
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 import torch
+from lightning import LightningModule, Trainer
 from torch import nn
 
 from icenet_mp.callbacks import ActivationSaver
@@ -23,70 +25,75 @@ class ReusedLayerModel(nn.Module):
         return self.shared(self.shared(x))
 
 
-def test_attach_rejects_unknown_layer(tmp_path: Path) -> None:
-    """Reject unknown layer paths."""
-    saver = ActivationSaver(["missing"], tmp_path)
-    model = nn.Sequential(nn.Linear(2, 2))
+class TestActivationSaver:
+    def test_attach_rejects_unknown_layer(self, tmp_path: Path) -> None:
+        """Reject unknown layer paths."""
+        saver = ActivationSaver(["missing"], tmp_path)
+        model = nn.Sequential(nn.Linear(2, 2))
 
-    with pytest.raises(ValueError, match="missing"):
+        with pytest.raises(ValueError, match="missing"):
+            saver.attach(model)
+
+    def test_layer_hook_keeps_first_fire_per_batch(self, tmp_path: Path) -> None:
+        """Keep only the first activation when a layer fires twice."""
+        saver = ActivationSaver(["shared"], tmp_path)
+        model = ReusedLayerModel()
+        saver.attach(model)
+        saver.on_test_batch_start(
+            MagicMock(spec=Trainer), MagicMock(spec=LightningModule), {}, 0
+        )
+
+        inputs = torch.tensor([[1.0, 3.0]])
+        output = model(inputs)
+
+        assert torch.equal(output, 4 * inputs)
+        assert torch.equal(saver._current_activations["shared"], 2 * inputs)
+        saver.detach()
+
+    def test_batch_payload_and_metadata_are_written(self, tmp_path: Path) -> None:
+        """Write batch payloads and evaluation metadata."""
+        saver = ActivationSaver(["0"], tmp_path, save_inputs=True)
+        model = nn.Sequential(nn.Linear(2, 2, bias=False))
         saver.attach(model)
 
+        trainer = MagicMock(spec=Trainer)
+        pl_module = MagicMock(spec=LightningModule)
+        sic_batch = torch.tensor([[1.0, 2.0]])
+        batch = {
+            "sic": sic_batch,
+            "metadata": "not-a-tensor",
+        }
+        saver.on_test_batch_start(trainer, pl_module, batch, 7)
+        model(sic_batch)
+        saver.on_test_batch_end(trainer, pl_module, None, batch, 7)
 
-def test_layer_hook_keeps_first_fire_per_batch(tmp_path: Path) -> None:
-    """Keep only the first activation when a layer fires twice."""
-    saver = ActivationSaver(["shared"], tmp_path)
-    model = ReusedLayerModel()
-    saver.attach(model)
-    saver.on_test_batch_start(None, None, {}, 0)  # type: ignore[arg-type]
+        payload_path = tmp_path / "batch_00007.pt"
+        payload = torch.load(payload_path, weights_only=False)
 
-    inputs = torch.tensor([[1.0, 3.0]])
-    output = model(inputs)
+        assert payload["batch_idx"] == 7
+        assert payload["layer_paths"] == ["0"]
+        assert set(payload["activations"]) == {"0"}
+        assert set(payload["inputs"]) == {"sic"}
+        assert torch.equal(payload["inputs"]["sic"], sic_batch)
 
-    torch.testing.assert_close(output, 4 * inputs)
-    torch.testing.assert_close(saver._current_activations["shared"], 2 * inputs)
-    saver.detach()
+        saver.on_test_end(trainer, pl_module)
+        metadata = json.loads((tmp_path / "metadata.json").read_text())
 
+        assert metadata["layer_paths"] == ["0"]
+        assert metadata["save_inputs"] is True
+        assert metadata["batch_file_template"] == "batch_{batch_idx:05d}.pt"
+        assert saver._handles == []
 
-def test_batch_payload_and_metadata_are_written(tmp_path: Path) -> None:
-    """Write batch payloads and evaluation metadata."""
-    saver = ActivationSaver(["0"], tmp_path, save_inputs=True)
-    model = nn.Sequential(nn.Linear(2, 2, bias=False))
-    saver.attach(model)
+    def test_empty_layer_list_is_disabled(self, tmp_path: Path) -> None:
+        """Leave the callback disabled when no layers are configured."""
+        output_dir = tmp_path / "activations"
+        saver = ActivationSaver([], output_dir)
 
-    batch = {
-        "sic": torch.tensor([[1.0, 2.0]]),
-        "metadata": "not-a-tensor",
-    }
-    saver.on_test_batch_start(None, None, batch, 7)  # type: ignore[arg-type]
-    model(batch["sic"])
-    saver.on_test_batch_end(None, None, None, batch, 7)  # type: ignore[arg-type]
+        trainer = MagicMock(spec=Trainer)
+        pl_module = MagicMock(spec=LightningModule)
+        saver.on_test_start(trainer, pl_module)
+        saver.on_test_batch_start(trainer, pl_module, {}, 0)
+        saver.on_test_batch_end(trainer, pl_module, None, {}, 0)
+        saver.on_test_end(trainer, pl_module)
 
-    payload_path = tmp_path / "batch_00007.pt"
-    payload = torch.load(payload_path, weights_only=False)
-
-    assert payload["batch_idx"] == 7
-    assert payload["layer_paths"] == ["0"]
-    assert set(payload["activations"]) == {"0"}
-    assert set(payload["inputs"]) == {"sic"}
-    torch.testing.assert_close(payload["inputs"]["sic"], batch["sic"])
-
-    saver.on_test_end(None, None)  # type: ignore[arg-type]
-    metadata = json.loads((tmp_path / "metadata.json").read_text())
-
-    assert metadata["layer_paths"] == ["0"]
-    assert metadata["save_inputs"] is True
-    assert metadata["batch_file_template"] == "batch_{batch_idx:05d}.pt"
-    assert saver._handles == []
-
-
-def test_empty_layer_list_is_disabled(tmp_path: Path) -> None:
-    """Leave the callback disabled when no layers are configured."""
-    output_dir = tmp_path / "activations"
-    saver = ActivationSaver([], output_dir)
-
-    saver.on_test_start(None, None)  # type: ignore[arg-type]
-    saver.on_test_batch_start(None, None, {}, 0)  # type: ignore[arg-type]
-    saver.on_test_batch_end(None, None, None, {}, 0)  # type: ignore[arg-type]
-    saver.on_test_end(None, None)  # type: ignore[arg-type]
-
-    assert not output_dir.exists()
+        assert not output_dir.exists()

--- a/tests/callbacks/test_activation_saver.py
+++ b/tests/callbacks/test_activation_saver.py
@@ -18,10 +18,12 @@ class ReusedLayerModel(nn.Module):
             self.shared.weight.copy_(2 * torch.eye(2))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply the shared layer twice."""
         return self.shared(self.shared(x))
 
 
 def test_attach_rejects_unknown_layer(tmp_path: Path) -> None:
+    """Reject unknown layer paths."""
     saver = ActivationSaver(["missing"], tmp_path)
     model = nn.Sequential(nn.Linear(2, 2))
 
@@ -30,6 +32,7 @@ def test_attach_rejects_unknown_layer(tmp_path: Path) -> None:
 
 
 def test_layer_hook_keeps_first_fire_per_batch(tmp_path: Path) -> None:
+    """Keep only the first activation when a layer fires twice."""
     saver = ActivationSaver(["shared"], tmp_path)
     model = ReusedLayerModel()
     saver.attach(model)
@@ -44,6 +47,7 @@ def test_layer_hook_keeps_first_fire_per_batch(tmp_path: Path) -> None:
 
 
 def test_batch_payload_and_metadata_are_written(tmp_path: Path) -> None:
+    """Write batch payloads and evaluation metadata."""
     saver = ActivationSaver(["0"], tmp_path, save_inputs=True)
     model = nn.Sequential(nn.Linear(2, 2, bias=False))
     saver.attach(model)
@@ -54,13 +58,7 @@ def test_batch_payload_and_metadata_are_written(tmp_path: Path) -> None:
     }
     saver.on_test_batch_start(None, None, batch, 7)  # type: ignore[arg-type]
     model(batch["sic"])
-    saver.on_test_batch_end(  # type: ignore[arg-type]
-        None,
-        None,
-        None,
-        batch,
-        7,
-    )
+    saver.on_test_batch_end(None, None, None, batch, 7)  # type: ignore[arg-type]
 
     payload_path = tmp_path / "batch_00007.pt"
     payload = torch.load(payload_path, weights_only=False)
@@ -81,6 +79,7 @@ def test_batch_payload_and_metadata_are_written(tmp_path: Path) -> None:
 
 
 def test_empty_layer_list_is_disabled(tmp_path: Path) -> None:
+    """Leave the callback disabled when no layers are configured."""
     output_dir = tmp_path / "activations"
     saver = ActivationSaver([], output_dir)
 

--- a/tests/callbacks/test_activation_saver.py
+++ b/tests/callbacks/test_activation_saver.py
@@ -1,0 +1,92 @@
+import json
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+from icenet_mp.callbacks import ActivationSaver
+
+
+class ReusedLayerModel(nn.Module):
+    """Tiny model that calls the same layer twice in one forward pass."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.shared = nn.Linear(2, 2, bias=False)
+        with torch.no_grad():
+            self.shared.weight.copy_(2 * torch.eye(2))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.shared(self.shared(x))
+
+
+def test_attach_rejects_unknown_layer(tmp_path: Path) -> None:
+    saver = ActivationSaver(["missing"], tmp_path)
+    model = nn.Sequential(nn.Linear(2, 2))
+
+    with pytest.raises(ValueError, match="missing"):
+        saver.attach(model)
+
+
+def test_layer_hook_keeps_first_fire_per_batch(tmp_path: Path) -> None:
+    saver = ActivationSaver(["shared"], tmp_path)
+    model = ReusedLayerModel()
+    saver.attach(model)
+    saver.on_test_batch_start(None, None, {}, 0)  # type: ignore[arg-type]
+
+    inputs = torch.tensor([[1.0, 3.0]])
+    output = model(inputs)
+
+    torch.testing.assert_close(output, 4 * inputs)
+    torch.testing.assert_close(saver._current_activations["shared"], 2 * inputs)
+    saver.detach()
+
+
+def test_batch_payload_and_metadata_are_written(tmp_path: Path) -> None:
+    saver = ActivationSaver(["0"], tmp_path, save_inputs=True)
+    model = nn.Sequential(nn.Linear(2, 2, bias=False))
+    saver.attach(model)
+
+    batch = {
+        "sic": torch.tensor([[1.0, 2.0]]),
+        "metadata": "not-a-tensor",
+    }
+    saver.on_test_batch_start(None, None, batch, 7)  # type: ignore[arg-type]
+    model(batch["sic"])
+    saver.on_test_batch_end(  # type: ignore[arg-type]
+        None,
+        None,
+        None,
+        batch,
+        7,
+    )
+
+    payload_path = tmp_path / "batch_00007.pt"
+    payload = torch.load(payload_path, weights_only=False)
+
+    assert payload["batch_idx"] == 7
+    assert payload["layer_paths"] == ["0"]
+    assert set(payload["activations"]) == {"0"}
+    assert set(payload["inputs"]) == {"sic"}
+    torch.testing.assert_close(payload["inputs"]["sic"], batch["sic"])
+
+    saver.on_test_end(None, None)  # type: ignore[arg-type]
+    metadata = json.loads((tmp_path / "metadata.json").read_text())
+
+    assert metadata["layer_paths"] == ["0"]
+    assert metadata["save_inputs"] is True
+    assert metadata["batch_file_template"] == "batch_{batch_idx:05d}.pt"
+    assert saver._handles == []
+
+
+def test_empty_layer_list_is_disabled(tmp_path: Path) -> None:
+    output_dir = tmp_path / "activations"
+    saver = ActivationSaver([], output_dir)
+
+    saver.on_test_start(None, None)  # type: ignore[arg-type]
+    saver.on_test_batch_start(None, None, {}, 0)  # type: ignore[arg-type]
+    saver.on_test_batch_end(None, None, None, {}, 0)  # type: ignore[arg-type]
+    saver.on_test_end(None, None)  # type: ignore[arg-type]
+
+    assert not output_dir.exists()

--- a/tests/callbacks/test_activation_saver.py
+++ b/tests/callbacks/test_activation_saver.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -10,8 +11,8 @@ from torch import nn
 from icenet_mp.callbacks import ActivationSaver
 
 
-class ReusedLayerModel(nn.Module):
-    """Tiny model that calls the same layer twice in one forward pass."""
+class MinimalReusedLayerModel(nn.Module):
+    """Minimal model that calls the same layer twice in one forward pass."""
 
     def __init__(self) -> None:
         """Initialise the repeated-layer test model."""
@@ -23,6 +24,31 @@ class ReusedLayerModel(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Apply the shared layer twice."""
         return self.shared(self.shared(x))
+
+
+class MinimalRolloutModel(nn.Module):
+    """Minimal model that calls `self.processor` twice, simulating two rollout steps."""
+
+    def __init__(self) -> None:
+        """Initialise the two-step rollout test model."""
+        super().__init__()
+        self.processor = nn.Linear(2, 2, bias=False)
+        with torch.no_grad():
+            self.processor.weight.copy_(2 * torch.eye(2))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the processor twice, as if performing a two-step rollout."""
+        first_step = self.processor(x)
+        return self.processor(first_step)
+
+
+class MinimalLightningModule(LightningModule):
+    """Minimal LightningModule exposing a named submodule for attach() to hook."""
+
+    def __init__(self) -> None:
+        """Initialise a LightningModule with one hookable layer."""
+        super().__init__()
+        self.layer = nn.Linear(2, 2)
 
 
 class TestActivationSaver:
@@ -37,7 +63,7 @@ class TestActivationSaver:
     def test_layer_hook_keeps_first_fire_per_batch(self, tmp_path: Path) -> None:
         """Keep only the first activation when a layer fires twice."""
         saver = ActivationSaver(["shared"], tmp_path)
-        model = ReusedLayerModel()
+        model = MinimalReusedLayerModel()
         saver.attach(model)
         saver.on_test_batch_start(
             MagicMock(spec=Trainer), MagicMock(spec=LightningModule), {}, 0
@@ -97,3 +123,48 @@ class TestActivationSaver:
         saver.on_test_end(trainer, pl_module)
 
         assert not output_dir.exists()
+
+    def test_processor_rollout_counter_keeps_first_step_only(
+        self, tmp_path: Path
+    ) -> None:
+        """Increment the rollout counter per processor call and keep only step 0."""
+        saver = ActivationSaver(["processor"], tmp_path)
+        model = MinimalRolloutModel()
+        saver.attach(model)
+        saver.on_test_batch_start(
+            MagicMock(spec=Trainer), MagicMock(spec=LightningModule), {}, 0
+        )
+
+        inputs = torch.tensor([[1.0, 3.0]])
+        model(inputs)
+
+        assert torch.equal(saver._current_activations["processor"], 2 * inputs)
+        saver.detach()
+
+    def test_batch_end_warns_about_uncaptured_layers(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warn when a configured layer never fired its hook this batch."""
+        saver = ActivationSaver(["0"], tmp_path)
+        model = nn.Sequential(nn.Linear(2, 2))
+        saver.attach(model)
+
+        trainer = MagicMock(spec=Trainer)
+        pl_module = MagicMock(spec=LightningModule)
+        saver.on_test_batch_start(trainer, pl_module, {}, 0)
+        # The model is never called, so "0"'s forward hook never fires.
+        with caplog.at_level(logging.WARNING):
+            saver.on_test_batch_end(trainer, pl_module, None, {}, 0)
+
+        assert "no activation captured for layers ['0']" in caplog.text
+        saver.detach()
+
+    def test_on_test_start_attaches_hooks_when_enabled(self, tmp_path: Path) -> None:
+        """Attach hooks automatically when on_test_start runs and layers are configured."""
+        saver = ActivationSaver(["layer"], tmp_path)
+        pl_module = MinimalLightningModule()
+
+        saver.on_test_start(MagicMock(spec=Trainer), pl_module)
+
+        assert len(saver._handles) > 0
+        saver.detach()

--- a/tests/callbacks/test_activation_saver.py
+++ b/tests/callbacks/test_activation_saver.py
@@ -12,6 +12,7 @@ class ReusedLayerModel(nn.Module):
     """Tiny model that calls the same layer twice in one forward pass."""
 
     def __init__(self) -> None:
+        """Initialise the repeated-layer test model."""
         super().__init__()
         self.shared = nn.Linear(2, 2, bias=False)
         with torch.no_grad():

--- a/tests/callbacks/test_metric_summary_callback.py
+++ b/tests/callbacks/test_metric_summary_callback.py
@@ -1,9 +1,11 @@
+import logging
 from unittest.mock import MagicMock
 
 import pytest
 import torch
 from lightning import LightningModule, Trainer
 from lightning.pytorch.loggers import WandbLogger
+from lightning.pytorch.trainer.states import TrainerFn
 from torchmetrics import MeanAbsoluteError, MetricCollection
 
 from icenet_mp.callbacks.metric_summary_callback import MetricSummaryCallback
@@ -159,6 +161,273 @@ class TestOnTestEnd:
         mock_logger.log_metrics.assert_called_once()
         metrics_call_args = mock_logger.log_metrics.call_args[0][0]
         assert "test_mae_daily_mean" in metrics_call_args
+
+
+class TestLogPerEpochMetrics:
+    """Tests for log_per_epoch_metrics."""
+
+    def test_skips_during_sanity_checking(
+        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
+    ) -> None:
+        """Do not log anything while Lightning's sanity check is running."""
+        mock_trainer.sanity_checking = True
+        metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
+        metric_collection.update(torch.zeros(1), torch.ones(1))
+
+        callback.log_per_epoch_metrics(mock_trainer, metric_collection, stage="test")
+
+        mock_logger = mock_trainer.loggers[0]
+        mock_logger.log_metrics.assert_not_called()
+
+    def test_skips_metrics_that_were_never_updated(
+        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
+    ) -> None:
+        """Skip metrics in the collection whose update() was never called."""
+        metric_collection = MetricCollection(
+            {"mae": MeanAbsoluteError(), "unused": MeanAbsoluteError()}
+        )
+        metric_collection["mae"].update(torch.zeros(1), torch.ones(1))
+
+        callback.log_per_epoch_metrics(mock_trainer, metric_collection, stage="test")
+
+        mock_logger = mock_trainer.loggers[0]
+        mock_logger.log_metrics.assert_called_once()
+        logged_metrics = mock_logger.log_metrics.call_args[0][0]
+        assert "test_mae_mean" in logged_metrics
+        assert "test_unused_mean" not in logged_metrics
+
+
+class TestLogPerRunMetrics:
+    """Tests for log_per_run_metrics."""
+
+    def test_skips_during_sanity_checking(
+        self,
+        callback: MetricSummaryCallback,
+        mock_trainer: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Return before evaluating anything while Lightning's sanity check is running."""
+        mock_trainer.sanity_checking = True
+
+        with caplog.at_level(logging.WARNING):
+            callback.log_per_run_metrics(mock_trainer, {})
+
+        assert caplog.text == ""
+
+    def test_warns_and_skips_without_wandb_logger(
+        self,
+        callback: MetricSummaryCallback,
+        mock_trainer: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Warn and skip logging when no WandbLogger/run is available."""
+        with caplog.at_level(logging.WARNING):
+            callback.log_per_run_metrics(mock_trainer, {})
+
+        assert "W&B is not being used as a logger" in caplog.text
+
+    def test_skips_metrics_that_were_never_updated(
+        self,
+        callback: MetricSummaryCallback,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Skip metrics whose update() was never called when building the per-day plot."""
+        mock_wandb = MagicMock()
+        mock_get_wandb_run = MagicMock()
+        monkeypatch.setattr(
+            "icenet_mp.callbacks.metric_summary_callback.wandb", mock_wandb
+        )
+        monkeypatch.setattr(
+            "icenet_mp.callbacks.metric_summary_callback.get_wandb_run",
+            mock_get_wandb_run,
+        )
+
+        class MockWandbRun:
+            def __init__(self) -> None:
+                self.log = MagicMock()
+
+        mock_wandb.Run = MockWandbRun
+        mock_get_wandb_run.return_value = MockWandbRun()
+
+        trainer = MagicMock(spec=Trainer)
+        trainer.sanity_checking = False
+
+        metric_collection = MetricCollection(
+            {"mae_daily": MAEPerForecastDay(), "unused_daily": MAEPerForecastDay()}
+        )
+        preds = torch.randn(1, 3, 1, 2, 2)
+        targets = torch.randn(1, 3, 1, 2, 2)
+        metric_collection["mae_daily"].update(preds, targets)
+
+        callback.log_per_run_metrics(trainer, {"test": metric_collection})
+
+        mock_wandb.plot.line_series.assert_called_once()
+        line_series_kwargs = mock_wandb.plot.line_series.call_args[1]
+        assert line_series_kwargs["title"] == "mae_daily_per_forecast_day"
+
+
+class TestEpochStartResets:
+    """Tests for the on_*_epoch_start metric-reset hooks."""
+
+    def test_on_test_epoch_start_resets_test_metrics(
+        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
+    ) -> None:
+        """Reset test_metrics at the start of a test epoch."""
+        metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
+        metric_collection.update(torch.zeros(1), torch.ones(1))
+        pl_module = MagicMock(spec=LightningModule)
+        pl_module.test_metrics = metric_collection
+
+        callback.on_test_epoch_start(mock_trainer, pl_module)
+
+        assert metric_collection["mae"]._update_called is False
+
+    def test_on_train_epoch_start_resets_train_metrics(
+        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
+    ) -> None:
+        """Reset train_metrics at the start of a training epoch."""
+        metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
+        metric_collection.update(torch.zeros(1), torch.ones(1))
+        pl_module = MagicMock(spec=LightningModule)
+        pl_module.train_metrics = metric_collection
+
+        callback.on_train_epoch_start(mock_trainer, pl_module)
+
+        assert metric_collection["mae"]._update_called is False
+
+    def test_on_validation_epoch_start_resets_validation_metrics(
+        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
+    ) -> None:
+        """Reset validation_metrics at the start of a validation epoch."""
+        metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
+        metric_collection.update(torch.zeros(1), torch.ones(1))
+        pl_module = MagicMock(spec=LightningModule)
+        pl_module.validation_metrics = metric_collection
+
+        callback.on_validation_epoch_start(mock_trainer, pl_module)
+
+        assert metric_collection["mae"]._update_called is False
+
+
+class TestOnTrainEpochEnd:
+    """Tests for on_train_epoch_end."""
+
+    def test_logs_when_train_metrics_present(
+        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
+    ) -> None:
+        """Log per-epoch metrics when train_metrics is a MetricCollection."""
+        metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
+        metric_collection.update(torch.zeros(1), torch.ones(1))
+        pl_module = MagicMock(spec=LightningModule)
+        pl_module.train_metrics = metric_collection
+
+        callback.on_train_epoch_end(mock_trainer, pl_module)
+
+        mock_logger = mock_trainer.loggers[0]
+        mock_logger.log_metrics.assert_called_once()
+
+    def test_warns_when_train_metrics_missing(
+        self,
+        callback: MetricSummaryCallback,
+        mock_trainer: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Warn when train_metrics is not a MetricCollection."""
+        pl_module = MagicMock(spec=LightningModule)
+        pl_module.train_metrics = "invalid"
+
+        with caplog.at_level(logging.WARNING):
+            callback.on_train_epoch_end(mock_trainer, pl_module)
+
+        assert "Could not load train metrics!" in caplog.text
+
+
+class TestOnValidationEpochEnd:
+    """Tests for on_validation_epoch_end."""
+
+    def test_logs_when_validation_metrics_present(
+        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
+    ) -> None:
+        """Log per-epoch metrics when validation_metrics is a MetricCollection."""
+        metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
+        metric_collection.update(torch.zeros(1), torch.ones(1))
+        pl_module = MagicMock(spec=LightningModule)
+        pl_module.validation_metrics = metric_collection
+
+        callback.on_validation_epoch_end(mock_trainer, pl_module)
+
+        mock_logger = mock_trainer.loggers[0]
+        mock_logger.log_metrics.assert_called_once()
+
+    def test_warns_when_validation_metrics_missing(
+        self,
+        callback: MetricSummaryCallback,
+        mock_trainer: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Warn when validation_metrics is not a MetricCollection."""
+        pl_module = MagicMock(spec=LightningModule)
+        pl_module.validation_metrics = "invalid"
+
+        with caplog.at_level(logging.WARNING):
+            callback.on_validation_epoch_end(mock_trainer, pl_module)
+
+        assert "Could not load validation metrics!" in caplog.text
+
+
+class TestTeardown:
+    """Tests for teardown's per-stage metric collection."""
+
+    def test_fitting_stage_collects_train_and_validation_metrics(
+        self,
+        callback: MetricSummaryCallback,
+        mock_trainer: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Gather both train and validation metrics for a fit run."""
+        pl_module = MagicMock(spec=LightningModule)
+        pl_module.train_metrics = MetricCollection({"mae": MeanAbsoluteError()})
+        pl_module.validation_metrics = MetricCollection({"mae": MeanAbsoluteError()})
+        mock_log_per_run_metrics = MagicMock()
+        monkeypatch.setattr(callback, "log_per_run_metrics", mock_log_per_run_metrics)
+
+        callback.teardown(mock_trainer, pl_module, stage=TrainerFn.FITTING.value)
+
+        mock_log_per_run_metrics.assert_called_once()
+        metrics = mock_log_per_run_metrics.call_args[0][1]
+        assert set(metrics) == {"train", "validation"}
+
+    def test_fitting_stage_warns_when_metrics_missing(
+        self,
+        callback: MetricSummaryCallback,
+        mock_trainer: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Warn for each stage whose metrics collection is missing during a fit run."""
+        pl_module = MagicMock(spec=LightningModule)
+        pl_module.train_metrics = "invalid"
+        pl_module.validation_metrics = "invalid"
+
+        with caplog.at_level(logging.WARNING):
+            callback.teardown(mock_trainer, pl_module, stage=TrainerFn.FITTING.value)
+
+        assert "Could not load train metrics!" in caplog.text
+        assert "Could not load validation metrics!" in caplog.text
+
+    def test_testing_stage_warns_when_test_metrics_missing(
+        self,
+        callback: MetricSummaryCallback,
+        mock_trainer: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Warn when test_metrics is missing during a test run."""
+        pl_module = MagicMock(spec=LightningModule)
+        pl_module.test_metrics = "invalid"
+
+        with caplog.at_level(logging.WARNING):
+            callback.teardown(mock_trainer, pl_module, stage=TrainerFn.TESTING.value)
+
+        assert "Could not load test metrics!" in caplog.text
 
 
 class TestMetricCalculations:

--- a/tests/callbacks/test_metric_summary_callback.py
+++ b/tests/callbacks/test_metric_summary_callback.py
@@ -70,7 +70,7 @@ class TestOnTestEnd:
         """Test on_test_end when test_metrics is not a MetricCollection."""
         mock_module.test_metrics = "invalid"
 
-        callback.on_test_end(mock_trainer, mock_module)
+        callback.on_test_epoch_end(mock_trainer, mock_module)
 
         # Should not raise an error, just log a warning
         mock_logger = mock_trainer.loggers[0]


### PR DESCRIPTION
## Summary

Adds focused unit coverage for the `ActivationSaver` evaluation callback.

## Coverage added

- invalid layer paths fail with an actionable error
- repeated layer calls keep only the first activation for a batch
- tensor inputs and captured activations are persisted in the expected batch payload
- metadata is written at test end
- hooks are detached after evaluation
- an empty layer list remains a no-op

This PR is test-only and does not change runtime behavior.

Part of #62.