### PR TITLE
Document Apple Silicon Conda workaround

### DIFF
--- a/notebooks/seaice_env_min.yml
+++ b/notebooks/seaice_env_min.yml
@@ -1,3 +1,7 @@
+# Apple Silicon (M1/M2/M3/M4): force Conda to resolve ARM64 packages when
+# creating this legacy notebook environment:
+#   CONDA_SUBDIR=osx-arm64 conda env create -f seaice_env_min.yml
+# This avoids Conda selecting x86_64 TensorFlow/Keras builds on Apple Silicon.
 name: seaice_env_min
 channels:
   - conda-forge


### PR DESCRIPTION
## Summary

Documents the existing Apple Silicon workaround for the legacy `seaice_env_min.yml` notebook environment.

## Changes

- add the `CONDA_SUBDIR=osx-arm64` creation command directly to the affected environment file
- explain why it is needed for TensorFlow/Keras resolution on Apple Silicon
- make no dependency or runtime changes

Closes #176.