### PR TITLE
Clean up contributor guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ Welcome! Thanks for your interest in contributing to this project.
 
 - We manage our day-to-day work on this internal [project management board](https://github.com/alan-turing-institute/ice-station-zebra-project-board).
 - Our [list of open issues](https://github.com/alan-turing-institute/icenet-mp/issues) is on GitHub.
-- Contact us at by [email](mailto:SeaIce@turing.ac.uk).
+- Contact us by [email](mailto:SeaIce@turing.ac.uk).
 
 ## Submitting changes
 
-- Please open a [GitHub Pull Request](https://github.com/alan-turing-institute/icenet-mp/pull/new/main) with a clear explanation of what you've done (read more about [pull requests](http://help.github.com/pull-requests/)).
+- Please open a [GitHub Pull Request](https://github.com/alan-turing-institute/icenet-mp/pull/new/main) with a clear explanation of what you've done (read more about [pull requests](https://docs.github.com/en/pull-requests)).
 - We use the [feature branch workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow), with each Pull Request squashed into a single commit on `main`.
 
 ## Coding conventions


### PR DESCRIPTION
## Summary

Makes two small corrections to the contributor guide.

## Changes

- fix the contact sentence from `Contact us at by email` to `Contact us by email`
- replace the old `http://help.github.com/pull-requests/` reference with GitHub's current HTTPS pull-request documentation
- make no workflow, code, or test changes

Documentation only.