### PR TITLE
Correct sea-ice extent metric documentation

### DIFF
--- a/icenet_mp/metrics/sie_error_abs.py
+++ b/icenet_mp/metrics/sie_error_abs.py
@@ -10,8 +10,8 @@ class SeaIceExtentErrorPerForecastDay(Metric):
     """Sea Ice Extent error (SIEError) metric (in km^2) for use at multiple lead times.
 
     The SIE error is calculated as the absolute difference between the predicted and
-    true sea ice extent for each forecast day. Sea ice presence is defined by having
-    a probability greater than the threshold value.
+    true sea ice extent for each forecast day. Sea ice presence is defined by sea ice
+    concentration greater than the threshold value.
     """
 
     def __init__(self, pixel_size: int = 25) -> None:
@@ -43,9 +43,9 @@ class SeaIceExtentErrorPerForecastDay(Metric):
         Parameters
         ----------
         preds : torch.Tensor
-            Model predictions of shape (B, T, H, W).
+            Model predictions of shape (B, T, C, H, W).
         target : torch.Tensor
-            Ground truth values of shape (B, T, H, W).
+            Ground truth values of shape (B, T, C, H, W).
         _sample_weight : Optional[torch.Tensor]
             Ignored (present for API compatibility).
 


### PR DESCRIPTION
## Summary

Corrects the public documentation for `SeaIceExtentErrorPerForecastDay` so it matches the tensor contract used by the implementation.

## Changes

- document prediction and target tensors as `(B, T, C, H, W)`
- describe the 0.15 threshold as sea-ice concentration rather than probability
- make no metric or runtime behavior changes

Documentation only.