### PR TITLE
Separate LR scheduler config

### DIFF
--- a/icenet_mp/config/base.yaml
+++ b/icenet_mp/config/base.yaml
@@ -4,7 +4,7 @@ defaults:
   - evaluate: default
   - loggers:
     - wandb
-  - loss: huber
+  - loss: amse
   - model: quick_test
   - predict: sic-osisaf-2d
   - random: default

--- a/icenet_mp/config/baseline/01_unet.yaml
+++ b/icenet_mp/config/baseline/01_unet.yaml
@@ -1,6 +1,7 @@
 # @package _global_
 defaults:
   - /base
+  - override /loss: huber
   - override /model: unet
   - _self_
 

--- a/icenet_mp/config/baseline/02_cnn_unet_cnn.yaml
+++ b/icenet_mp/config/baseline/02_cnn_unet_cnn.yaml
@@ -1,5 +1,6 @@
 # @package _global_
 defaults:
   - /base
+  - override /loss: huber
   - override /model: cnn_unet_cnn
   - _self_

--- a/icenet_mp/config/baseline/03_cnn_vit_cnn.yaml
+++ b/icenet_mp/config/baseline/03_cnn_vit_cnn.yaml
@@ -1,5 +1,6 @@
 # @package _global_
 defaults:
   - /base
+  - override /loss: huber
   - override /model: cnn_vit_cnn
   - _self_

--- a/icenet_mp/config/baseline/04_ddpm.yaml
+++ b/icenet_mp/config/baseline/04_ddpm.yaml
@@ -1,6 +1,7 @@
 # @package _global_
 defaults:
   - /base
+  - override /loss: huber
   - override /model: ddpm
   - override /train/optimizer: ddpm
   - override /train/scheduler: ddpm

--- a/icenet_mp/config/baseline/05_piecewise_unet_piecewise.yaml
+++ b/icenet_mp/config/baseline/05_piecewise_unet_piecewise.yaml
@@ -1,5 +1,6 @@
 # @package _global_
 defaults:
   - /base
+  - override /loss: huber
   - override /model: piecewise_unet_piecewise
   - _self_

--- a/icenet_mp/config/baseline/cnn_gsta_cnn.yaml
+++ b/icenet_mp/config/baseline/cnn_gsta_cnn.yaml
@@ -1,5 +1,6 @@
 # @package _global_
 defaults:
   - /base
+  - override /loss: huber
   - override /model: cnn_gsta_cnn
   - _self_

--- a/icenet_mp/config/baseline/dc_unet_dc.yaml
+++ b/icenet_mp/config/baseline/dc_unet_dc.yaml
@@ -1,6 +1,7 @@
 # @package _global_
 defaults:
   - /base
+  - override /loss: huber
   - override /model: dc_unet_dc
   - _self_
 

--- a/icenet_mp/config/train/default.yaml
+++ b/icenet_mp/config/train/default.yaml
@@ -6,6 +6,7 @@ defaults:
     - learning_rate
     - metric_summary
     - plotting
+  - lr_scheduler: default
   - multistage: default
   - optimizer: default
   - scheduler: default

--- a/icenet_mp/config/train/lr_scheduler/default.yaml
+++ b/icenet_mp/config/train/lr_scheduler/default.yaml
@@ -1,0 +1,4 @@
+# Used by Lightning to log the learning rate
+frequency: 1
+interval: epoch
+name: learning-rate

--- a/icenet_mp/config/train/scheduler/ddpm.yaml
+++ b/icenet_mp/config/train/scheduler/ddpm.yaml
@@ -3,5 +3,4 @@ defaults:
   - default
   - _self_
 
-scheduler_parameters:
-  eta_min: 5e-6
+eta_min: 5e-6

--- a/icenet_mp/config/train/scheduler/default.yaml
+++ b/icenet_mp/config/train/scheduler/default.yaml
@@ -1,13 +1,4 @@
 # PyTorch Lightning scheduler settings
 _target_: torch.optim.lr_scheduler.CosineAnnealingLR
-
-# These parameters are part of an `lr_scheduler_config`
-lr_scheduler_parameters:
-  frequency: 1
-  interval: epoch
-  name: learning-rate  # used when logging to W&B
-
-# These parameters are passed to the scheduler instance
-scheduler_parameters:
-  eta_min: 1e-6
-  T_max: ${...trainer.max_epochs}
+eta_min: 1e-6
+T_max: ${..trainer.max_epochs}

--- a/icenet_mp/model_service.py
+++ b/icenet_mp/model_service.py
@@ -77,6 +77,7 @@ class ModelService:
             latitudes_fn=lambda: builder.data_module.latitudes,
             longitudes_fn=lambda: builder.data_module.longitudes,
             loss=config["loss"],
+            lr_scheduler=config["train"]["lr_scheduler"],
             mask_dir=str(builder.data_module.mask_directory),
             n_forecast_steps=builder.data_module.n_forecast_steps,
             n_history_steps=builder.data_module.n_history_steps,
@@ -182,6 +183,7 @@ class ModelService:
         current_model = model or self.model
         current_model.optimizer_cfg = config["optimizer"]
         current_model.scheduler_cfg = config["scheduler"]
+        current_model.lr_scheduler_cfg = config["lr_scheduler"]
         if "loss" in config:
             current_model.loss_cfg = config["loss"]
         trainer = self.build_trainer(

--- a/icenet_mp/models/base_model.py
+++ b/icenet_mp/models/base_model.py
@@ -2,13 +2,14 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from copy import deepcopy
 from functools import cached_property
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import hydra
 import torch
 from lightning import LightningModule
 from lightning.pytorch.utilities.types import (
     LRSchedulerConfigType,
+    LRSchedulerTypeUnion,
     OptimizerConfig,
     OptimizerLRScheduler,
     OptimizerLRSchedulerConfig,
@@ -24,6 +25,9 @@ from icenet_mp.metrics import (
     SeaIceExtentErrorPerForecastDay,
 )
 from icenet_mp.types import DataSpace, Hemisphere, ModelStepOutput, TensorNTCHW
+
+if TYPE_CHECKING:
+    from torch.optim import Optimizer
 
 
 class BaseModel(LightningModule, ABC):
@@ -42,6 +46,7 @@ class BaseModel(LightningModule, ABC):
         latitudes_fn: Callable[[], dict[str, list[float]]] | None = None,
         longitudes_fn: Callable[[], dict[str, list[float]]] | None = None,
         loss: DictConfig,
+        lr_scheduler: DictConfig,
         metrics: list[str] | None = None,
         n_forecast_steps: int,
         n_history_steps: int,
@@ -88,6 +93,7 @@ class BaseModel(LightningModule, ABC):
         # Store the optimizer, scheduler and loss configs
         self.optimizer_cfg = optimizer
         self.scheduler_cfg = scheduler
+        self.lr_scheduler_cfg = lr_scheduler
         self.loss_cfg = loss
 
         # Metrics
@@ -133,8 +139,8 @@ class BaseModel(LightningModule, ABC):
 
     def configure_optimizers(self) -> OptimizerLRScheduler:
         """Construct the optimizer and optional scheduler from the config."""
-        # Optimizer
-        optimizer = hydra.utils.instantiate(
+        # Create the optimizer
+        optimizer: Optimizer = hydra.utils.instantiate(
             self.optimizer_cfg,
             params=filter(lambda p: p.requires_grad, self.parameters()),
         )
@@ -143,19 +149,26 @@ class BaseModel(LightningModule, ABC):
         if not self.scheduler_cfg:
             return OptimizerConfig(optimizer=optimizer)
 
-        # Scheduler
-        scheduler = hydra.utils.instantiate(
-            self.scheduler_cfg["scheduler_parameters"],
-            _target_=self.scheduler_cfg["_target_"],
-            optimizer=optimizer,
+        # Create the scheduler
+        scheduler: LRSchedulerTypeUnion = hydra.utils.instantiate(
+            self.scheduler_cfg, optimizer=optimizer
+        )
+
+        # Create the Lightning LRScheduler wrapper
+        lr_scheduler = LRSchedulerConfigType(
+            frequency=self.lr_scheduler_cfg.get("frequency", 1),
+            interval=self.lr_scheduler_cfg.get("interval", "epoch"),
+            monitor=self.lr_scheduler_cfg.get("monitor"),
+            name=self.lr_scheduler_cfg.get("name"),
+            reduce_on_plateau=self.lr_scheduler_cfg.get("reduce_on_plateau", False),
+            scheduler=scheduler,
+            strict=self.lr_scheduler_cfg.get("strict", True),
         )
 
         # Return the optimizer and scheduler
         return OptimizerLRSchedulerConfig(
             optimizer=optimizer,
-            lr_scheduler=LRSchedulerConfigType(
-                scheduler=scheduler, **self.scheduler_cfg["lr_scheduler_parameters"]
-            ),
+            lr_scheduler=lr_scheduler,
         )
 
     @abstractmethod

--- a/icenet_mp/models/multistage/decoder_stage.py
+++ b/icenet_mp/models/multistage/decoder_stage.py
@@ -97,6 +97,7 @@ class DecoderStage(BaseModel):
             mask_dir=mask_dir,
             hemisphere=encoders[0].hemisphere,
             input_spaces=[s.to_dict() for s in encoders[0].input_spaces],
+            lr_scheduler=copy.deepcopy(encoders[0].lr_scheduler_cfg),
             n_forecast_steps=encoders[0].n_forecast_steps,
             n_history_steps=encoders[0].n_history_steps,
             name=f"{target_dataset_name}_decoder".replace("-", "_"),

--- a/icenet_mp/models/multistage/encoder_stage.py
+++ b/icenet_mp/models/multistage/encoder_stage.py
@@ -86,6 +86,7 @@ class EncoderStage(BaseModel):
             latent_space=template.encoders[0].data_space_out.shape,
             latitudes_fn=template.latitudes_fn,
             longitudes_fn=template.longitudes_fn,
+            lr_scheduler=copy.deepcopy(template.lr_scheduler_cfg),
             n_forecast_steps=template.n_forecast_steps,
             n_history_steps=template.n_history_steps,
             name=f"{dataset}_encoder".replace("-", "_"),

--- a/icenet_mp/models/multistage/processor_stage.py
+++ b/icenet_mp/models/multistage/processor_stage.py
@@ -83,6 +83,7 @@ class ProcessorStage(EncodeProcessDecode):
             hemisphere=decoder_model.hemisphere,
             input_spaces=[s.to_dict() for s in decoder_model.input_spaces],
             loss=copy.deepcopy(decoder_model.loss_cfg),
+            lr_scheduler=copy.deepcopy(decoder_model.lr_scheduler_cfg),
             n_forecast_steps=decoder_model.n_forecast_steps,
             n_history_steps=decoder_model.n_history_steps,
             name=f"processor_{decoder_model.n_history_steps}_to_{decoder_model.n_forecast_steps}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ known-third-party = ["wandb"]
     "S101", # allow asserts in tests
     "INP001", # allow implicit namespace in tests
     "PLR0913", # allow unlimited arguments in tests
+    "PLR0917", # allow unlimited positional arguments in tests
     "PLR2004", # allow magic-number comparison in tests
 ]
 

--- a/tests/config/test_hydra.py
+++ b/tests/config/test_hydra.py
@@ -40,7 +40,7 @@ class TestHydraConfigLoading:
 
     def test_loss_defaults_resolved_from_base(self) -> None:
         cfg = self.load_config()
-        assert cfg.loss._target_ == "torch.nn.HuberLoss"
+        assert cfg.loss._target_ == "icenet_mp.losses.amse_loss.AMSELoss"
         assert cfg.loss.delta == pytest.approx(0.5)
 
     def test_scalar_override_applied(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,6 +195,7 @@ def cfg_model_service() -> DictConfig:
                 "callbacks": {},
                 "optimizer": {},
                 "scheduler": {},
+                "lr_scheduler": {},
                 "trainer": {},
             },
         }
@@ -231,10 +232,16 @@ def cfg_scheduler() -> DictConfig:
     return DictConfig(
         {
             "_target_": "torch.optim.lr_scheduler.LinearLR",
-            "lr_scheduler_parameters": {"frequency": 1, "interval": "epoch"},
-            "scheduler_parameters": {"start_factor": 0.2, "end_factor": 0.8},
+            "start_factor": 0.2,
+            "end_factor": 0.8,
         }
     )
+
+
+@pytest.fixture
+def cfg_lr_scheduler() -> DictConfig:
+    """Test configuration for a scheduler's Lightning `lr_scheduler_config` wrapper."""
+    return DictConfig({"frequency": 1, "interval": "epoch"})
 
 
 @pytest.fixture(scope="session")

--- a/tests/losses/test_loss_config.py
+++ b/tests/losses/test_loss_config.py
@@ -57,6 +57,7 @@ class TestLossConfig:
                 output_space=cfg_output_space,
                 optimizer=DictConfig({}),
                 scheduler=DictConfig({}),
+                lr_scheduler=DictConfig({}),
                 # loss intentionally omitted
             )
 
@@ -76,6 +77,7 @@ class TestLossConfig:
             output_space=cfg_output_space,
             optimizer=DictConfig({}),
             scheduler=DictConfig({}),
+            lr_scheduler=DictConfig({}),
             loss=LOSS_CONFIGS[loss_name],
         )
         assert isinstance(model.loss_fn, LOSS_TYPES[loss_name])
@@ -97,5 +99,6 @@ class TestLossConfig:
                 output_space=cfg_output_space,
                 optimizer=DictConfig({}),
                 scheduler=DictConfig({}),
+                lr_scheduler=DictConfig({}),
                 loss=bad_loss,
             )

--- a/tests/models/multistage/conftest.py
+++ b/tests/models/multistage/conftest.py
@@ -13,6 +13,7 @@ def encoder_stage(
     cfg_output_space: DictConfig,
     cfg_optimizer: DictConfig,
     cfg_scheduler: DictConfig,
+    cfg_lr_scheduler: DictConfig,
     cfg_loss: DictConfig,
     cfg_decoder: DictConfig,
 ) -> EncoderStage:
@@ -31,6 +32,7 @@ def encoder_stage(
         optimizer=cfg_optimizer,
         output_space=cfg_output_space,
         scheduler=cfg_scheduler,
+        lr_scheduler=cfg_lr_scheduler,
         loss=cfg_loss,
     )
 
@@ -44,6 +46,7 @@ def decoder_stage(
     cfg_output_space: DictConfig,
     cfg_optimizer: DictConfig,
     cfg_scheduler: DictConfig,
+    cfg_lr_scheduler: DictConfig,
     cfg_loss: DictConfig,
 ) -> DecoderStage:
     """A DecoderStage wrapping `encoder_stage`. Requires two history steps."""
@@ -60,5 +63,6 @@ def decoder_stage(
         optimizer=cfg_optimizer,
         output_space=cfg_output_space,
         scheduler=cfg_scheduler,
+        lr_scheduler=cfg_lr_scheduler,
         loss=cfg_loss,
     )

--- a/tests/models/multistage/test_decoder_stage.py
+++ b/tests/models/multistage/test_decoder_stage.py
@@ -79,6 +79,7 @@ class TestDecoderStage:
         cfg_output_space: DictConfig,
         cfg_optimizer: DictConfig,
         cfg_scheduler: DictConfig,
+        cfg_lr_scheduler: DictConfig,
         cfg_loss: DictConfig,
     ) -> None:
         with pytest.raises(ValueError, match="at least two history steps"):
@@ -95,6 +96,7 @@ class TestDecoderStage:
                 optimizer=cfg_optimizer,
                 output_space=cfg_output_space,
                 scheduler=cfg_scheduler,
+                lr_scheduler=cfg_lr_scheduler,
                 loss=cfg_loss,
             )
 
@@ -107,6 +109,7 @@ class TestDecoderStage:
         cfg_output_space: DictConfig,
         cfg_optimizer: DictConfig,
         cfg_scheduler: DictConfig,
+        cfg_lr_scheduler: DictConfig,
         cfg_loss: DictConfig,
     ) -> None:
         with pytest.raises(ValueError, match="target_variable_indices selects"):
@@ -123,6 +126,7 @@ class TestDecoderStage:
                 optimizer=cfg_optimizer,
                 output_space=cfg_output_space,
                 scheduler=cfg_scheduler,
+                lr_scheduler=cfg_lr_scheduler,
                 loss=cfg_loss,
             )
 
@@ -154,6 +158,7 @@ class TestDecoderStage:
         cfg_output_space: DictConfig,
         cfg_optimizer: DictConfig,
         cfg_scheduler: DictConfig,
+        cfg_lr_scheduler: DictConfig,
         cfg_loss: DictConfig,
     ) -> None:
         # from_template reads n_history_steps/n_forecast_steps/etc. off the source
@@ -173,6 +178,7 @@ class TestDecoderStage:
             optimizer=cfg_optimizer,
             output_space=cfg_output_space,
             scheduler=cfg_scheduler,
+            lr_scheduler=cfg_lr_scheduler,
             loss=cfg_loss,
         )
 

--- a/tests/models/multistage/test_encoder_stage.py
+++ b/tests/models/multistage/test_encoder_stage.py
@@ -14,6 +14,7 @@ class TestEncoderStage:
         cfg_output_space: DictConfig,
         cfg_optimizer: DictConfig,
         cfg_scheduler: DictConfig,
+        cfg_lr_scheduler: DictConfig,
         cfg_loss: DictConfig,
     ) -> None:
         encoder_stage = EncoderStage(
@@ -35,6 +36,7 @@ class TestEncoderStage:
             optimizer=cfg_optimizer,
             output_space=cfg_output_space,
             scheduler=cfg_scheduler,
+            lr_scheduler=cfg_lr_scheduler,
             loss=cfg_loss,
         )
 
@@ -101,6 +103,7 @@ class TestEncoderStage:
             output_space=cfg_output_space,
             optimizer=DictConfig({}),
             scheduler=DictConfig({}),
+            lr_scheduler=DictConfig({}),
             loss=cfg_loss,
             target_variable_indices=[0],
         )

--- a/tests/models/multistage/test_processor_stage.py
+++ b/tests/models/multistage/test_processor_stage.py
@@ -36,6 +36,7 @@ class TestProcessorStage:
         cfg_output_space: DictConfig,
         cfg_optimizer: DictConfig,
         cfg_scheduler: DictConfig,
+        cfg_lr_scheduler: DictConfig,
         cfg_loss: DictConfig,
         cfg_decoder: DictConfig,
     ) -> EncoderStage:
@@ -60,6 +61,7 @@ class TestProcessorStage:
             optimizer=cfg_optimizer,
             output_space=cfg_output_space,
             scheduler=cfg_scheduler,
+            lr_scheduler=cfg_lr_scheduler,
             loss=cfg_loss,
         )
 
@@ -74,6 +76,7 @@ class TestProcessorStage:
         cfg_output_space: DictConfig,
         cfg_optimizer: DictConfig,
         cfg_scheduler: DictConfig,
+        cfg_lr_scheduler: DictConfig,
         cfg_loss: DictConfig,
     ) -> ProcessorStage:
         return ProcessorStage(
@@ -88,6 +91,7 @@ class TestProcessorStage:
             optimizer=cfg_optimizer,
             output_space=cfg_output_space,
             scheduler=cfg_scheduler,
+            lr_scheduler=cfg_lr_scheduler,
             loss=cfg_loss,
         )
 
@@ -229,6 +233,7 @@ class TestProcessorStage:
         cfg_output_space: DictConfig,
         cfg_optimizer: DictConfig,
         cfg_scheduler: DictConfig,
+        cfg_lr_scheduler: DictConfig,
         cfg_loss: DictConfig,
     ) -> None:
         skip_connection_decoder = DictConfig(
@@ -250,6 +255,7 @@ class TestProcessorStage:
             optimizer=cfg_optimizer,
             output_space=cfg_output_space,
             scheduler=cfg_scheduler,
+            lr_scheduler=cfg_lr_scheduler,
             loss=cfg_loss,
         )
         processor_stage = ProcessorStage(
@@ -264,6 +270,7 @@ class TestProcessorStage:
             optimizer=cfg_optimizer,
             output_space=cfg_output_space,
             scheduler=cfg_scheduler,
+            lr_scheduler=cfg_lr_scheduler,
             loss=cfg_loss,
         )
 

--- a/tests/models/test_base_model.py
+++ b/tests/models/test_base_model.py
@@ -40,6 +40,7 @@ class TestBaseModel:
                 output_space={"channels": 1, "name": "target", "shape": (2, 2)},
                 optimizer=DictConfig({}),
                 scheduler=DictConfig({}),
+                lr_scheduler=DictConfig({}),
             )
 
     def test_init_invalid_history_steps(self) -> None:
@@ -54,6 +55,7 @@ class TestBaseModel:
                 output_space={"channels": 1, "name": "target", "shape": (2, 2)},
                 optimizer=DictConfig({}),
                 scheduler=DictConfig({}),
+                lr_scheduler=DictConfig({}),
             )
 
     @pytest.mark.parametrize("test_input_chw", [(4, 512, 512), (1, 10, 20)])
@@ -89,6 +91,7 @@ class TestBaseModel:
             output_space=output_space,
             optimizer=DictConfig({}),
             scheduler=DictConfig({}),
+            lr_scheduler=DictConfig({}),
         )
         assert model.name == "fake data"
         assert model.input_spaces[0].channels == test_input_chw[0]
@@ -111,6 +114,7 @@ class TestBaseModel:
             output_space=cfg_output_space,
             optimizer=DictConfig({}),
             scheduler=DictConfig({}),
+            lr_scheduler=DictConfig({}),
         )
         # Test loss
         prediction = torch.zeros(1, 1, 1, 1)
@@ -131,6 +135,7 @@ class TestBaseModel:
             output_space=cfg_output_space,
             optimizer=cfg_optimizer,
             scheduler=DictConfig({}),
+            lr_scheduler=DictConfig({}),
         )
         opt_sched_cfg = model.configure_optimizers()
         assert isinstance(opt_sched_cfg, dict)
@@ -145,6 +150,7 @@ class TestBaseModel:
         cfg_optimizer: DictConfig,
         cfg_output_space: DictConfig,
         cfg_scheduler: DictConfig,
+        cfg_lr_scheduler: DictConfig,
     ) -> None:
         model = FakeDataModel(
             name="dummy",
@@ -154,6 +160,7 @@ class TestBaseModel:
             output_space=cfg_output_space,
             optimizer=cfg_optimizer,
             scheduler=cfg_scheduler,
+            lr_scheduler=cfg_lr_scheduler,
         )
         opt_sched_cfg = model.configure_optimizers()
         assert isinstance(opt_sched_cfg, dict)
@@ -164,6 +171,8 @@ class TestBaseModel:
         assert isinstance(scheduler, torch.optim.lr_scheduler.LinearLR)
         assert scheduler.start_factor == 0.2
         assert scheduler.end_factor == 0.8
+        assert lr_scheduler_cfg.get("frequency") == 1
+        assert lr_scheduler_cfg.get("interval") == "epoch"
 
     def test_test_step(
         self,
@@ -197,6 +206,7 @@ class TestBaseModel:
             output_space=cfg_output_space,
             optimizer=cfg_optimizer,
             scheduler=cfg_scheduler,
+            lr_scheduler=DictConfig({}),
         )
         output_shape = batch["target"].shape
         output = model.test_step(batch, 0)
@@ -237,6 +247,7 @@ class TestBaseModel:
             output_space=cfg_output_space,
             optimizer=cfg_optimizer,
             scheduler=cfg_scheduler,
+            lr_scheduler=DictConfig({}),
         )
         output = model.training_step(batch, 0)
         assert isinstance(output, ModelStepOutput)
@@ -274,6 +285,7 @@ class TestBaseModel:
             output_space=cfg_output_space,
             optimizer=cfg_optimizer,
             scheduler=cfg_scheduler,
+            lr_scheduler=DictConfig({}),
         )
         output = model.validation_step(batch, 0)
         assert isinstance(output, ModelStepOutput)

--- a/tests/models/test_ddpm.py
+++ b/tests/models/test_ddpm.py
@@ -26,6 +26,7 @@ class TestDDPM:
             },
             optimizer={},
             scheduler={},
+            lr_scheduler={},
             start_out_channels=4,
             timesteps=4,
             use_autoregressive=use_autoregressive,

--- a/tests/models/test_encode_process_decode.py
+++ b/tests/models/test_encode_process_decode.py
@@ -31,6 +31,7 @@ class TestEncodeProcessDecode:
             output_space=cfg_output_space,
             optimizer=DictConfig({}),
             scheduler=DictConfig({}),
+            lr_scheduler=DictConfig({}),
             loss=cfg_loss,
             target_variable_indices=[0],
         )
@@ -71,6 +72,7 @@ class TestEncodeProcessDecode:
             output_space=cfg_output_space,
             optimizer=DictConfig({}),
             scheduler=DictConfig({}),
+            lr_scheduler=DictConfig({}),
             target_variable_indices=[0],
         )
         result: torch.Tensor = model(
@@ -155,6 +157,7 @@ class TestEncodeProcessDecode:
             output_space=cfg_output_space,
             optimizer=DictConfig({}),
             scheduler=DictConfig({}),
+            lr_scheduler=DictConfig({}),
             target_variable_indices=[0],
         )
         assert model.multistage_only is True

--- a/tests/models/test_encode_process_decode.py
+++ b/tests/models/test_encode_process_decode.py
@@ -8,7 +8,7 @@ from icenet_mp.models import EncodeProcessDecode
 @pytest.mark.parametrize("test_n_forecast_steps", [1, 2, 5])
 @pytest.mark.parametrize("test_n_history_steps", [1, 2, 5])
 class TestEncodeProcessDecode:
-    def test_init(  # noqa: PLR0917
+    def test_init(
         self,
         cfg_decoder: DictConfig,
         cfg_encoders: DictConfig,
@@ -46,7 +46,7 @@ class TestEncodeProcessDecode:
         assert model.output_space.shape == cfg_output_space["shape"]
 
     @pytest.mark.parametrize("test_batch_size", [1, 2, 5])
-    def test_forward(  # noqa: PLR0917
+    def test_forward(
         self,
         cfg_decoder: DictConfig,
         cfg_encoders: DictConfig,
@@ -99,7 +99,7 @@ class TestEncodeProcessDecode:
             cfg_output_space["shape"][1],
         )
 
-    def test_processor_default_does_not_require_multistage(  # noqa: PLR0917
+    def test_processor_default_does_not_require_multistage(
         self,
         cfg_decoder: DictConfig,
         cfg_encoders: DictConfig,
@@ -123,11 +123,12 @@ class TestEncodeProcessDecode:
             output_space=cfg_output_space,
             optimizer=DictConfig({}),
             scheduler=DictConfig({}),
+            lr_scheduler=DictConfig({}),
             target_variable_indices=[0],
         )
         assert model.multistage_only is False
 
-    def test_processor_with_custom_loss_multistage_only(  # noqa: PLR0917
+    def test_processor_with_custom_loss_multistage_only(
         self,
         cfg_decoder: DictConfig,
         cfg_encoders: DictConfig,

--- a/tests/models/test_persistence.py
+++ b/tests/models/test_persistence.py
@@ -40,6 +40,7 @@ class TestPersistence:
             output_space=output_space,
             optimizer={},
             scheduler={},
+            lr_scheduler={},
             target_variable_indices=list(range(test_output_shape[2])),
         )
         batch = {
@@ -82,6 +83,7 @@ class TestPersistence:
             },
             optimizer={},
             scheduler={},
+            lr_scheduler={},
             target_variable_indices=[0],
         )
         assert model.configure_optimizers() is None, (

--- a/tests/test_model_service.py
+++ b/tests/test_model_service.py
@@ -68,6 +68,7 @@ class TestModelService:
         assert kwargs["n_history_steps"] == 3
         assert kwargs["optimizer"] is cfg_model_service["train"]["optimizer"]
         assert kwargs["scheduler"] is cfg_model_service["train"]["scheduler"]
+        assert kwargs["lr_scheduler"] is cfg_model_service["train"]["lr_scheduler"]
         assert kwargs["_recursive_"] is False
         assert kwargs["_convert_"] == "object"
 


### PR DESCRIPTION
Separate LR scheduler config (which controls how Lightning logs learning rate to e.g. W&B) from the options which control scheduler behaviour (e.g. eta_min).