### PR TITLE
Hyperparameter optimisation: UNet

### DIFF
--- a/icenet_mp/config/baseline/01_unet.yaml
+++ b/icenet_mp/config/baseline/01_unet.yaml
@@ -1,7 +1,6 @@
 # @package _global_
 defaults:
   - /base
-  - override /loss: huber
   - override /model: unet
   - _self_
 

--- a/icenet_mp/config/baseline/01_unet.yaml
+++ b/icenet_mp/config/baseline/01_unet.yaml
@@ -8,5 +8,5 @@ defaults:
 # Reduce learning rate and increase weight decay to reduce overfitting
 train:
   optimizer:
-    lr: 1e-3
-    weight_decay: 0.05
+    lr: 1.5e-4
+    weight_decay: 1.5e-3

--- a/icenet_mp/config/model/unet.yaml
+++ b/icenet_mp/config/model/unet.yaml
@@ -15,12 +15,12 @@ encoders:
 
 processor:
   _target_: icenet_mp.models.processors.UNetProcessor
-  kernel_size: 3
+  kernel_size: 7
   start_out_channels: 128
 
 decoder:
   _target_: icenet_mp.models.decoders.NaiveLinearDecoder
   mask_type: active
-  restrict_range: sigmoid
+  restrict_range: none
   skip_connection:
-    method: none
+    method: additive


### PR DESCRIPTION
Changed parameters based on a recent sweep. Note that this we still suffer from the problem of poor time evolution (i.e. the rolled-out predictions still look like t=0).

## Sweep command
```
uv run imp sweep initialise --sweep-yaml icenet_mp/config/01_unet.sweep.local.yaml --config-name baseline/01_unet ++train.trainer.max_epochs=10 platform=jasmin data=full_south loss=amse
```

## Sweep YAML

```yaml
name: 01_unet
n_trials: 100
sampler: tpe
seed: 0
metric:
  name: validation_loss
  goal: minimize
parameters:
  model.decoder.restrict_range:
    type: categorical
    choices: ["clamp", "none", "sigmoid", "tanh"]
  model.decoder.skip_connection.method:
    type: categorical
    choices: ["additive", "convolutional", "gated", "none"]
  model.processor.kernel_size:
    type: categorical
    choices: [3, 5, 7, 9]
  model.processor.start_out_channels:
    type: categorical
    choices: [32, 64, 128, 256]
  train.optimizer.lr:
    type: float
    low: 1.0e-5
    high: 1.0e-2
    log: true
  train.optimizer.weight_decay:
    type: float
    low: 1.0e-6
    high: 1.0e-2
    log: true
```


## [Sweep results](https://wandb.ai/turing-seaice/train/sweeps/celolk5q)

<img width="1542" height="429" alt="Screenshot 2026-09-03 at 11 16 28" src="https://github.com/user-attachments/assets/505b4b08-5808-49cc-8c6b-9304c7227db6" />

```
😈 [2026-08-24 10:43:00] Study contains 61 trial(s): 33 completed, 28 failed
😈 [2026-08-24 10:43:00] Trial 41 performed best, with loss 0.000552.
😈 [2026-08-24 10:43:00] Best trial parameters:
😈 [2026-08-24 10:43:00]   model.decoder.restrict_range: none
😈 [2026-08-24 10:43:00]   model.decoder.skip_connection.method: additive
😈 [2026-08-24 10:43:00]   model.processor.kernel_size: 7
😈 [2026-08-24 10:43:00]   model.processor.start_out_channels: 128
😈 [2026-08-24 10:43:00]   train.optimizer.lr: 0.00014737735131922422
😈 [2026-08-24 10:43:00]   train.optimizer.weight_decay: 0.001576471979350734
```

## Results

Running on DGX Spark
- `uv run imp train --config-name baseline/01_unet platform=spark data=full_south predict=sic-osisaf-7d ++train.trainer.max_epochs=10`
- [solar-shadow-758](https://wandb.ai/turing-seaice/train/runs/93tnu7p7)
- `uv run imp evaluate --config-name baseline/01_unet platform=spark data=full_south predict=sic-osisaf-7d --checkpoint ../../../srv/icenet-mp/training/wandb/run-20260901_125654-93tnu7p7/checkpoints/epoch\=2-step\=10464.ckpt`
- [jolly-thunder-434](https://wandb.ai/turing-seaice/evaluate/runs/jm855yog)

https://github.com/user-attachments/assets/da00cead-6396-4430-9738-cce010ad6849

https://github.com/user-attachments/assets/569e5a5d-22ee-4cb6-b0e3-9ea1c2193610

<img width="45%" alt="W B Chart 07_09_2026, 13_50_41" src="https://github.com/user-attachments/assets/0cc7d506-fbf5-4353-9372-956e49398f26" />
<img width="45%" alt="W B Chart 07_09_2026, 13_50_45" src="https://github.com/user-attachments/assets/bf65ada5-116e-4dba-83bc-1ff7e602757a" />
<img width="45%" alt="W B Chart 07_09_2026, 13_50_49" src="https://github.com/user-attachments/assets/b536bd69-ccc1-484e-bba9-689d0cfc28ea" />
<img width="45%" alt="canvas" src="https://github.com/user-attachments/assets/660c4586-8150-4ef1-960a-1b739aff7d9b" />

Closes #378