### PR TITLE
Add SEAS5 CDS trajectory dataset recipe

### DIFF
--- a/docs/src/user-guide/commands.md
+++ b/docs/src/user-guide/commands.md
@@ -20,6 +20,17 @@ To create the synthetic dataset, use:
 uv run imp datasets create --config-name synthetic
 ```
 
+To exercise forecast-indexed ingestion with the small SEAS5 trajectory recipe, use:
+
+```bash
+uv run imp datasets create --config-name seas5_demo
+uv run imp datasets inspect --config-name seas5_demo
+```
+
+This is an ingestion smoke test for Anemoi's trajectory layout: it preserves the
+forecast initialisation and lead-time axes instead of flattening them into analysis
+dates. It is not yet a training configuration for IceNet-MP.
+
 ## `datasets inspect`
 
 ```bash

--- a/icenet_mp/config/data/datasets/demo_sicnorth_seas5_1p0_2024_2024_24h_v1.yaml
+++ b/icenet_mp/config/data/datasets/demo_sicnorth_seas5_1p0_2024_2024_24h_v1.yaml
@@ -1,0 +1,36 @@
+demo-sicnorth-seas5-1p0-2024-2024-24h-v1:
+  name: demo-sicnorth-seas5-1p0-2024-2024-24h-v1
+  description: ECMWF SEAS5.1 sea-ice cover forecast for a northern-hemisphere download smoke test
+  attribution: ECMWF/C3S
+  licence: Copernicus Products Licence
+
+  # SEAS5 is forecast-indexed data, so preserve the forecast initialisation
+  # and lead-time axes rather than flattening it into analysis-style dates.
+  base_dates:
+    start: '2024-01-01T00:00:00'
+    end: '2024-01-01T00:00:00'
+    frequency: 24h
+
+  steps:
+    start: 24h
+    end: 168h
+    frequency: 24h
+
+  input:
+    mars:
+      use_cdsapi_dataset: seasonal-original-single-levels
+      class: c3
+      expver: '0001'
+      origin: ecmf
+      system: '51'
+      method: '1'
+      stream: mmsf
+      type: fc
+      levtype: sfc
+      param:
+      - 31.128  # sea-ice cover
+      grid: '1.0 / 1.0'
+      area: '90/-180/20/180'
+
+  output:
+    layout: trajectories

--- a/icenet_mp/config/data/datasets/demo_sicnorth_seas5_1p0_2024_2024_24h_v1.yaml
+++ b/icenet_mp/config/data/datasets/demo_sicnorth_seas5_1p0_2024_2024_24h_v1.yaml
@@ -28,7 +28,7 @@ demo-sicnorth-seas5-1p0-2024-2024-24h-v1:
       type: fc
       levtype: sfc
       param:
-      - 31.128  # sea-ice cover
+      - '31.128'  # sea-ice cover
       grid: '1.0 / 1.0'
       area: '90/-180/20/180'
 

--- a/icenet_mp/config/data/datasets/demo_sicnorth_seas5_1p0_2024_2024_24h_v1.yaml
+++ b/icenet_mp/config/data/datasets/demo_sicnorth_seas5_1p0_2024_2024_24h_v1.yaml
@@ -1,5 +1,6 @@
 demo-sicnorth-seas5-1p0-2024-2024-24h-v1:
   name: demo-sicnorth-seas5-1p0-2024-2024-24h-v1
+  group_as: sic-seas5
   description: ECMWF SEAS5.1 sea-ice cover forecast for a northern-hemisphere download smoke test
   attribution: ECMWF/C3S
   licence: Copernicus Products Licence

--- a/icenet_mp/config/data/datasets/demo_sicnorth_seas5_1p0_2024_2024_24h_v1.yaml
+++ b/icenet_mp/config/data/datasets/demo_sicnorth_seas5_1p0_2024_2024_24h_v1.yaml
@@ -16,6 +16,14 @@ demo-sicnorth-seas5-1p0-2024-2024-24h-v1:
     end: 168h
     frequency: 24h
 
+  # Anemoi's default statistics window holds out 20% of tiny datasets. For a
+  # single seven-step trajectory that would truncate the valid-time envelope
+  # and leave no complete trajectory for statistics. Keep this smoke-test
+  # trajectory whole.
+  statistics:
+    start: '2024-01-02T00:00:00'
+    end: '2024-01-08T00:00:00'
+
   input:
     mars:
       use_cdsapi_dataset: seasonal-original-single-levels

--- a/icenet_mp/config/data/seas5_demo.yaml
+++ b/icenet_mp/config/data/seas5_demo.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - datasets:
+    - demo_sicnorth_seas5_1p0_2024_2024_24h_v1
+  - _self_

--- a/icenet_mp/config/data/seas5_demo.yaml
+++ b/icenet_mp/config/data/seas5_demo.yaml
@@ -1,4 +1,5 @@
 defaults:
   - datasets:
     - demo_sicnorth_seas5_1p0_2024_2024_24h_v1
+  - split: seas5_demo
   - _self_

--- a/icenet_mp/config/data/split/seas5_demo.yaml
+++ b/icenet_mp/config/data/split/seas5_demo.yaml
@@ -1,0 +1,20 @@
+# Structural split for the ingestion-only SEAS5 demo configuration.
+# The demo is not intended for model training; each stage therefore exposes the
+# complete tiny dataset rather than claiming a meaningful statistical partition.
+batch_size: 1
+
+predict:
+  - start: null
+    end: null
+
+test:
+  - start: null
+    end: null
+
+train:
+  - start: null
+    end: null
+
+validate:
+  - start: null
+    end: null

--- a/icenet_mp/config/seas5_demo.yaml
+++ b/icenet_mp/config/seas5_demo.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - base
+  - override /data: seas5_demo
+  - _self_

--- a/tests/config/test_config_files.py
+++ b/tests/config/test_config_files.py
@@ -34,10 +34,17 @@ class TestConfigFiles:
         body = next(iter(data.values()))
 
         assert body.get("group_as"), "missing or empty 'group_as'"
-        dates = body.get("dates") or {}
-        assert dates.get("start"), "missing 'dates.start'"
-        assert dates.get("end"), "missing 'dates.end'"
-        assert dates.get("frequency"), "missing 'dates.frequency'"
+        if "base_dates" in body or "steps" in body:
+            base_dates = body.get("base_dates") or {}
+            steps = body.get("steps") or {}
+            for key in ("start", "end", "frequency"):
+                assert base_dates.get(key), f"missing 'base_dates.{key}'"
+                assert steps.get(key), f"missing 'steps.{key}'"
+        else:
+            dates = body.get("dates") or {}
+            assert dates.get("start"), "missing 'dates.start'"
+            assert dates.get("end"), "missing 'dates.end'"
+            assert dates.get("frequency"), "missing 'dates.frequency'"
         # anemoi's 'input' recipe shape varies (a single source, or a pipe/join/concat
         # combinator), so only its presence as a non-empty mapping is source-agnostic.
         assert isinstance(body.get("input"), dict), "missing 'input' recipe"

--- a/tests/ingestion/test_seas5_recipe.py
+++ b/tests/ingestion/test_seas5_recipe.py
@@ -6,10 +6,12 @@ import yaml
 
 from icenet_mp.ingestion.data_downloader import DataDownloader
 
-
 DATASET_NAME = "demo-sicnorth-seas5-1p0-2024-2024-24h-v1"
-RECIPE_PATH = files("icenet_mp.config") / "data" / "datasets" / (
-    "demo_sicnorth_seas5_1p0_2024_2024_24h_v1.yaml"
+RECIPE_PATH = (
+    files("icenet_mp.config")
+    / "data"
+    / "datasets"
+    / "demo_sicnorth_seas5_1p0_2024_2024_24h_v1.yaml"
 )
 
 
@@ -19,6 +21,7 @@ def _load_recipe() -> dict[str, Any]:
 
 
 def test_seas5_recipe_is_accepted_by_data_downloader(tmp_path: Path) -> None:
+    """Construct the SEAS5 recipe through DataDownloader without network access."""
     recipe = _load_recipe()
 
     downloader = DataDownloader(DATASET_NAME, tmp_path, recipe)
@@ -28,6 +31,7 @@ def test_seas5_recipe_is_accepted_by_data_downloader(tmp_path: Path) -> None:
 
 
 def test_seas5_recipe_uses_cds_forecast_trajectory() -> None:
+    """Keep the critical CDS trajectory request fields configured for SEAS5."""
     recipe = _load_recipe()
     mars = recipe["input"]["mars"]
 

--- a/tests/ingestion/test_seas5_recipe.py
+++ b/tests/ingestion/test_seas5_recipe.py
@@ -1,0 +1,39 @@
+from importlib.resources import files
+from pathlib import Path
+
+import yaml
+
+from icenet_mp.ingestion.data_downloader import DataDownloader
+
+
+DATASET_NAME = "demo-sicnorth-seas5-1p0-2024-2024-24h-v1"
+RECIPE_PATH = files("icenet_mp.config") / "data" / "datasets" / (
+    "demo_sicnorth_seas5_1p0_2024_2024_24h_v1.yaml"
+)
+
+
+def _load_recipe() -> dict:
+    config = yaml.safe_load(RECIPE_PATH.read_text())
+    return config[DATASET_NAME]
+
+
+def test_seas5_recipe_is_accepted_by_data_downloader(tmp_path: Path) -> None:
+    recipe = _load_recipe()
+
+    downloader = DataDownloader(DATASET_NAME, tmp_path, recipe)
+
+    assert downloader.name == DATASET_NAME
+    assert downloader.recipe is not None
+
+
+def test_seas5_recipe_uses_cds_forecast_trajectory() -> None:
+    recipe = _load_recipe()
+    mars = recipe["input"]["mars"]
+
+    assert recipe["output"]["layout"] == "trajectories"
+    assert mars["use_cdsapi_dataset"] == "seasonal-original-single-levels"
+    assert mars["origin"] == "ecmf"
+    assert mars["system"] == "51"
+    assert mars["param"] == [31.128]
+    assert mars["type"] == "fc"
+    assert mars["stream"] == "mmsf"

--- a/tests/ingestion/test_seas5_recipe.py
+++ b/tests/ingestion/test_seas5_recipe.py
@@ -1,5 +1,6 @@
 from importlib.resources import files
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -12,8 +13,8 @@ RECIPE_PATH = files("icenet_mp.config") / "data" / "datasets" / (
 )
 
 
-def _load_recipe() -> dict:
-    config = yaml.safe_load(RECIPE_PATH.read_text())
+def _load_recipe() -> dict[str, Any]:
+    config: dict[str, dict[str, Any]] = yaml.safe_load(RECIPE_PATH.read_text())
     return config[DATASET_NAME]
 
 
@@ -34,6 +35,6 @@ def test_seas5_recipe_uses_cds_forecast_trajectory() -> None:
     assert mars["use_cdsapi_dataset"] == "seasonal-original-single-levels"
     assert mars["origin"] == "ecmf"
     assert mars["system"] == "51"
-    assert mars["param"] == [31.128]
+    assert mars["param"] == ["31.128"]
     assert mars["type"] == "fc"
     assert mars["stream"] == "mmsf"

--- a/tests/ingestion/test_seas5_recipe.py
+++ b/tests/ingestion/test_seas5_recipe.py
@@ -2,6 +2,7 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import yaml
 
 from icenet_mp.ingestion.data_downloader import DataDownloader
@@ -42,3 +43,16 @@ def test_seas5_recipe_uses_cds_forecast_trajectory() -> None:
     assert mars["param"] == ["31.128"]
     assert mars["type"] == "fc"
     assert mars["stream"] == "mmsf"
+
+
+def test_seas5_statistics_cover_the_complete_demo_trajectory(tmp_path: Path) -> None:
+    """Keep the full forecast trajectory inside Anemoi's statistics envelope."""
+    downloader = DataDownloader(DATASET_NAME, tmp_path, _load_recipe())
+    base_dates = np.array(["2024-01-01T00:00:00"], dtype="datetime64[s]")
+    steps = np.arange(1, 8) * np.timedelta64(24, "h")
+
+    stats_filter = downloader.recipe.statistics.trajectory_statistics_filter(
+        base_dates, steps
+    )
+
+    assert stats_filter.mask(base_dates).tolist() == [True]


### PR DESCRIPTION
## Summary

- add a small ECMWF SEAS5.1 sea-ice-cover recipe backed by CDS `seasonal-original-single-levels`
- model SEAS5 as an Anemoi trajectory dataset, preserving forecast initialisation and lead-time axes
- use ECMWF system 51 with daily 24–168 h steps on a 1° northern-hemisphere domain
- add offline recipe-validation tests for the DataDownloader/Anemoi configuration and critical CDS request fields

## Testing

- added a test that constructs the recipe through `DataDownloader` without network access
- added assertions for the CDS dataset ID, ECMWF system, forecast stream/type and sea-ice parameter
- a live CDS download requires configured CDS credentials and is intentionally left to integration use
- full repository CI will run when the PR is opened

Part of #79.