### PR TITLE
Add simple runtime datatype test coverage

### DIFF
--- a/icenet_mp/types/simple_datatypes.py
+++ b/icenet_mp/types/simple_datatypes.py
@@ -8,14 +8,6 @@ from torch import Tensor
 from .typedefs import ArrayHW, TensorNTCHW
 
 
-class AnemoiDatasetStatus(NamedTuple):
-    """Status of an Anemoi dataset."""
-
-    copy_in_progress: bool
-    download_complete: bool
-    is_finalised: bool
-
-
 @dataclass
 class AnemoiCleanupArgs:
     """Arguments for anemoi cleanup."""
@@ -23,6 +15,14 @@ class AnemoiCleanupArgs:
     path: str
     command: str = "unused"
     delta: list[str] | None = None
+
+
+class AnemoiDatasetStatus(NamedTuple):
+    """Status of an Anemoi dataset."""
+
+    copy_in_progress: bool
+    download_complete: bool
+    is_finalised: bool
 
 
 @dataclass

--- a/tests/types/test_enums.py
+++ b/tests/types/test_enums.py
@@ -1,0 +1,55 @@
+import pytest
+
+from icenet_mp.types.enums import (
+    BetaSchedule,
+    MaskType,
+    RangeRestriction,
+    SkipConnectionType,
+)
+
+
+class TestEnums:
+    """Tests for the icenet_mp.types StrEnum classes."""
+
+    def test_beta_schedule_members(self) -> None:
+        """Expose the expected BetaSchedule members."""
+        assert {member.value for member in BetaSchedule} == {"linear", "cosine"}
+
+    def test_mask_type_members(self) -> None:
+        """Expose the expected MaskType members."""
+        assert {member.value for member in MaskType} == {"active", "land", "none"}
+
+    @pytest.mark.parametrize(
+        "member",
+        [
+            BetaSchedule.LINEAR,
+            MaskType.LAND,
+            RangeRestriction.SIGMOID,
+            SkipConnectionType.GATED,
+        ],
+        ids=lambda member: f"{type(member).__name__}.{member.name}",
+    )
+    def test_member_behaves_as_its_string_value(
+        self, member: BetaSchedule | MaskType | RangeRestriction | SkipConnectionType
+    ) -> None:
+        """Compare equal to, and behave as, its underlying string value."""
+        assert member == member.value
+        assert isinstance(member, str)
+
+    def test_range_restriction_members(self) -> None:
+        """Expose the expected RangeRestriction members."""
+        assert {member.value for member in RangeRestriction} == {
+            "clamp",
+            "none",
+            "sigmoid",
+            "tanh",
+        }
+
+    def test_skip_connection_type_members(self) -> None:
+        """Expose the expected SkipConnectionType members."""
+        assert {member.value for member in SkipConnectionType} == {
+            "additive",
+            "convolutional",
+            "gated",
+            "none",
+        }

--- a/tests/types/test_protocols.py
+++ b/tests/types/test_protocols.py
@@ -1,0 +1,25 @@
+from omegaconf import DictConfig
+
+from icenet_mp.types.protocols import SupportsMetadata
+
+
+class _WithMetadata:
+    def set_metadata(self, config: DictConfig, model_name: str) -> None:
+        self.config = config
+        self.model_name = model_name
+
+
+class _WithoutMetadata:
+    pass
+
+
+class TestSupportsMetadata:
+    """Tests for the SupportsMetadata protocol."""
+
+    def test_isinstance_false_when_set_metadata_is_missing(self) -> None:
+        """Reject an object that has no set_metadata method."""
+        assert not isinstance(_WithoutMetadata(), SupportsMetadata)
+
+    def test_isinstance_true_for_matching_method_signature(self) -> None:
+        """Accept an object that duck-types a matching set_metadata method."""
+        assert isinstance(_WithMetadata(), SupportsMetadata)

--- a/tests/types/test_simple_datatypes.py
+++ b/tests/types/test_simple_datatypes.py
@@ -1,0 +1,104 @@
+from unittest.mock import MagicMock
+
+import torch
+from matplotlib.colors import Normalize
+
+from icenet_mp.types import (
+    AnemoiCleanupArgs,
+    AnemoiDatasetStatus,
+    AnemoiFinaliseArgs,
+    AnemoiInitArgs,
+    AnemoiLoadArgs,
+    DiffColourmapSpec,
+    Metadata,
+    ProcessorOutput,
+)
+
+
+def test_anemoi_dataset_status_is_tuple_compatible() -> None:
+    status = AnemoiDatasetStatus(
+        copy_in_progress=False,
+        download_complete=True,
+        is_finalised=True,
+    )
+
+    assert tuple(status) == (False, True, True)
+    assert status.download_complete is True
+
+
+def test_anemoi_command_args_keep_expected_defaults() -> None:
+    recipe = MagicMock()
+
+    cleanup = AnemoiCleanupArgs(path="dataset.zarr")
+    initialise = AnemoiInitArgs(path="dataset.zarr", recipe=recipe)
+    load = AnemoiLoadArgs(path="dataset.zarr", recipe=recipe)
+    finalise = AnemoiFinaliseArgs(path="dataset.zarr", recipe=recipe)
+
+    assert cleanup.command == "unused"
+    assert cleanup.delta is None
+    assert initialise.command == "unused"
+    assert initialise.overwrite is False
+    assert initialise.recipe is recipe
+    assert load.command == "unused"
+    assert load.recipe is recipe
+    assert finalise.command == "unused"
+    assert finalise.recipe is recipe
+
+
+def test_diff_colourmap_spec_preserves_normalisation_and_bounds() -> None:
+    norm = Normalize(vmin=-1.0, vmax=1.0)
+
+    spec = DiffColourmapSpec(norm=norm, vmin=None, vmax=None, cmap="coolwarm")
+
+    assert spec.norm is norm
+    assert spec.vmin is None
+    assert spec.vmax is None
+    assert spec.cmap == "coolwarm"
+
+
+def test_metadata_defaults_are_independent_and_optional() -> None:
+    first = Metadata()
+    second = Metadata()
+
+    first.vars_by_source = {"era5": ["2t"]}
+
+    assert first.model is None
+    assert first.n_points is None
+    assert second.vars_by_source is None
+
+
+def test_metadata_accepts_training_summary_fields() -> None:
+    metadata = Metadata(
+        model="cnn-vit-cnn",
+        max_epochs=20,
+        current_epoch=7,
+        start="2017-01-01",
+        end="2019-12-31",
+        cadence="24h",
+        n_points=1095,
+        n_history_steps=3,
+        vars_by_source={"sic-ssmis": ["ice_conc"]},
+    )
+
+    assert metadata.model == "cnn-vit-cnn"
+    assert metadata.current_epoch == 7
+    assert metadata.n_history_steps == 3
+    assert metadata.vars_by_source == {"sic-ssmis": ["ice_conc"]}
+
+
+def test_processor_output_defaults_loss_to_none() -> None:
+    prediction = torch.randn(2, 3, 4, 5, 6)
+
+    output = ProcessorOutput(prediction=prediction)
+
+    assert output.prediction is prediction
+    assert output.loss is None
+
+
+def test_processor_output_keeps_custom_loss_tensor() -> None:
+    prediction = torch.randn(1, 2, 3, 4, 5)
+    loss = torch.tensor(0.25)
+
+    output = ProcessorOutput(prediction=prediction, loss=loss)
+
+    assert output.loss is loss

--- a/tests/types/test_simple_datatypes.py
+++ b/tests/types/test_simple_datatypes.py
@@ -48,6 +48,22 @@ class TestAnemoiCommandArgs:
         assert args.overwrite is False
         assert args.recipe is recipe
 
+    def test_inspect_preserves_requested_flags(self) -> None:
+        """Preserve every explicit inspect flag without hidden defaults."""
+        args = AnemoiInspectArgs(
+            detailed=True,
+            path="dataset.zarr",
+            progress=False,
+            size=True,
+            statistics=False,
+        )
+
+        assert args.detailed is True
+        assert args.path == "dataset.zarr"
+        assert args.progress is False
+        assert args.size is True
+        assert args.statistics is False
+
     def test_load_defaults(self) -> None:
         """Default AnemoiLoadArgs command while preserving the recipe."""
         recipe = MagicMock(spec=Recipe)
@@ -71,26 +87,6 @@ class TestAnemoiDatasetStatus:
 
         assert tuple(status) == (False, True, True)
         assert status.download_complete is True
-
-
-class TestAnemoiInspectArgs:
-    """Tests for AnemoiInspectArgs."""
-
-    def test_preserve_requested_flags(self) -> None:
-        """Preserve explicit inspect options without hidden defaults."""
-        inspect = AnemoiInspectArgs(
-            detailed=True,
-            path="dataset.zarr",
-            progress=False,
-            size=True,
-            statistics=False,
-        )
-
-        assert inspect.path == "dataset.zarr"
-        assert inspect.detailed is True
-        assert inspect.progress is False
-        assert inspect.size is True
-        assert inspect.statistics is False
 
 
 class TestDiffColourmapSpec:

--- a/tests/types/test_simple_datatypes.py
+++ b/tests/types/test_simple_datatypes.py
@@ -16,6 +16,7 @@ from icenet_mp.types import (
 
 
 def test_anemoi_dataset_status_is_tuple_compatible() -> None:
+    """Preserve tuple compatibility for Anemoi dataset status values."""
     status = AnemoiDatasetStatus(
         copy_in_progress=False,
         download_complete=True,
@@ -27,6 +28,7 @@ def test_anemoi_dataset_status_is_tuple_compatible() -> None:
 
 
 def test_anemoi_command_args_keep_expected_defaults() -> None:
+    """Keep expected defaults across Anemoi command argument dataclasses."""
     recipe = MagicMock()
 
     cleanup = AnemoiCleanupArgs(path="dataset.zarr")
@@ -46,6 +48,7 @@ def test_anemoi_command_args_keep_expected_defaults() -> None:
 
 
 def test_diff_colourmap_spec_preserves_normalisation_and_bounds() -> None:
+    """Preserve normalisation, bounds and colourmap configuration."""
     norm = Normalize(vmin=-1.0, vmax=1.0)
 
     spec = DiffColourmapSpec(norm=norm, vmin=None, vmax=None, cmap="coolwarm")
@@ -57,6 +60,7 @@ def test_diff_colourmap_spec_preserves_normalisation_and_bounds() -> None:
 
 
 def test_metadata_defaults_are_independent_and_optional() -> None:
+    """Keep Metadata defaults optional and independent across instances."""
     first = Metadata()
     second = Metadata()
 
@@ -68,6 +72,7 @@ def test_metadata_defaults_are_independent_and_optional() -> None:
 
 
 def test_metadata_accepts_training_summary_fields() -> None:
+    """Accept and preserve training-summary metadata fields."""
     metadata = Metadata(
         model="cnn-vit-cnn",
         max_epochs=20,
@@ -87,6 +92,7 @@ def test_metadata_accepts_training_summary_fields() -> None:
 
 
 def test_processor_output_defaults_loss_to_none() -> None:
+    """Default ProcessorOutput loss to None when omitted."""
     prediction = torch.randn(2, 3, 4, 5, 6)
 
     output = ProcessorOutput(prediction=prediction)
@@ -96,6 +102,7 @@ def test_processor_output_defaults_loss_to_none() -> None:
 
 
 def test_processor_output_keeps_custom_loss_tensor() -> None:
+    """Preserve an explicitly supplied ProcessorOutput loss tensor."""
     prediction = torch.randn(1, 2, 3, 4, 5)
     loss = torch.tensor(0.25)
 

--- a/tests/types/test_simple_datatypes.py
+++ b/tests/types/test_simple_datatypes.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import torch
+from anemoi.datasets.create.recipe import Recipe
 from matplotlib.colors import Normalize
 
 from icenet_mp.types import (
@@ -18,134 +19,169 @@ from icenet_mp.types import (
 )
 
 
-def test_anemoi_dataset_status_is_tuple_compatible() -> None:
-    """Preserve tuple compatibility for Anemoi dataset status values."""
-    status = AnemoiDatasetStatus(
-        copy_in_progress=False,
-        download_complete=True,
-        is_finalised=True,
-    )
+class TestAnemoiCommandArgs:
+    """Tests for the Anemoi CLI command argument dataclasses."""
 
-    assert tuple(status) == (False, True, True)
-    assert status.download_complete is True
+    def test_cleanup_defaults(self) -> None:
+        """Default AnemoiCleanupArgs command and delta when omitted."""
+        args = AnemoiCleanupArgs(path="dataset.zarr")
 
+        assert args.command == "unused"
+        assert args.delta is None
 
-def test_anemoi_command_args_keep_expected_defaults() -> None:
-    """Keep expected defaults across Anemoi command argument dataclasses."""
-    recipe = MagicMock()
+    def test_finalise_defaults(self) -> None:
+        """Default AnemoiFinaliseArgs command while preserving the recipe."""
+        recipe = MagicMock(spec=Recipe)
 
-    cleanup = AnemoiCleanupArgs(path="dataset.zarr")
-    initialise = AnemoiInitArgs(path="dataset.zarr", recipe=recipe)
-    load = AnemoiLoadArgs(path="dataset.zarr", recipe=recipe)
-    finalise = AnemoiFinaliseArgs(path="dataset.zarr", recipe=recipe)
+        args = AnemoiFinaliseArgs(path="dataset.zarr", recipe=recipe)
 
-    assert cleanup.command == "unused"
-    assert cleanup.delta is None
-    assert initialise.command == "unused"
-    assert initialise.overwrite is False
-    assert initialise.recipe is recipe
-    assert load.command == "unused"
-    assert load.recipe is recipe
-    assert finalise.command == "unused"
-    assert finalise.recipe is recipe
+        assert args.command == "unused"
+        assert args.recipe is recipe
 
+    def test_init_defaults(self) -> None:
+        """Default AnemoiInitArgs command and overwrite while preserving the recipe."""
+        recipe = MagicMock(spec=Recipe)
 
-def test_anemoi_inspect_args_preserve_requested_flags() -> None:
-    """Preserve explicit inspect options without hidden defaults."""
-    inspect = AnemoiInspectArgs(
-        detailed=True,
-        path="dataset.zarr",
-        progress=False,
-        size=True,
-        statistics=False,
-    )
+        args = AnemoiInitArgs(path="dataset.zarr", recipe=recipe)
 
-    assert inspect.path == "dataset.zarr"
-    assert inspect.detailed is True
-    assert inspect.progress is False
-    assert inspect.size is True
-    assert inspect.statistics is False
+        assert args.command == "unused"
+        assert args.overwrite is False
+        assert args.recipe is recipe
+
+    def test_load_defaults(self) -> None:
+        """Default AnemoiLoadArgs command while preserving the recipe."""
+        recipe = MagicMock(spec=Recipe)
+
+        args = AnemoiLoadArgs(path="dataset.zarr", recipe=recipe)
+
+        assert args.command == "unused"
+        assert args.recipe is recipe
 
 
-def test_diff_colourmap_spec_preserves_normalisation_and_bounds() -> None:
-    """Preserve normalisation, bounds and colourmap configuration."""
-    norm = Normalize(vmin=-1.0, vmax=1.0)
+class TestAnemoiDatasetStatus:
+    """Tests for AnemoiDatasetStatus."""
 
-    spec = DiffColourmapSpec(norm=norm, vmin=None, vmax=None, cmap="coolwarm")
+    def test_is_tuple_compatible(self) -> None:
+        """Preserve tuple compatibility for Anemoi dataset status values."""
+        status = AnemoiDatasetStatus(
+            copy_in_progress=False,
+            download_complete=True,
+            is_finalised=True,
+        )
 
-    assert spec.norm is norm
-    assert spec.vmin is None
-    assert spec.vmax is None
-    assert spec.cmap == "coolwarm"
-
-
-def test_metadata_defaults_are_independent_and_optional() -> None:
-    """Keep Metadata defaults optional and independent across instances."""
-    first = Metadata()
-    second = Metadata()
-
-    first.vars_by_source = {"era5": ["2t"]}
-
-    assert first.model is None
-    assert first.n_points is None
-    assert second.vars_by_source is None
+        assert tuple(status) == (False, True, True)
+        assert status.download_complete is True
 
 
-def test_metadata_accepts_training_summary_fields() -> None:
-    """Accept and preserve training-summary metadata fields."""
-    metadata = Metadata(
-        model="cnn-vit-cnn",
-        max_epochs=20,
-        current_epoch=7,
-        start="2017-01-01",
-        end="2019-12-31",
-        cadence="24h",
-        n_points=1095,
-        n_history_steps=3,
-        vars_by_source={"sic-ssmis": ["ice_conc"]},
-    )
+class TestAnemoiInspectArgs:
+    """Tests for AnemoiInspectArgs."""
 
-    assert metadata.model == "cnn-vit-cnn"
-    assert metadata.current_epoch == 7
-    assert metadata.n_history_steps == 3
-    assert metadata.vars_by_source == {"sic-ssmis": ["ice_conc"]}
+    def test_preserve_requested_flags(self) -> None:
+        """Preserve explicit inspect options without hidden defaults."""
+        inspect = AnemoiInspectArgs(
+            detailed=True,
+            path="dataset.zarr",
+            progress=False,
+            size=True,
+            statistics=False,
+        )
 
-
-def test_processor_output_defaults_loss_to_none() -> None:
-    """Default ProcessorOutput loss to None when omitted."""
-    prediction = torch.randn(2, 3, 4, 5, 6)
-
-    output = ProcessorOutput(prediction=prediction)
-
-    assert output.prediction is prediction
-    assert output.loss is None
+        assert inspect.path == "dataset.zarr"
+        assert inspect.detailed is True
+        assert inspect.progress is False
+        assert inspect.size is True
+        assert inspect.statistics is False
 
 
-def test_processor_output_keeps_custom_loss_tensor() -> None:
-    """Preserve an explicitly supplied ProcessorOutput loss tensor."""
-    prediction = torch.randn(1, 2, 3, 4, 5)
-    loss = torch.tensor(0.25)
+class TestDiffColourmapSpec:
+    """Tests for DiffColourmapSpec."""
 
-    output = ProcessorOutput(prediction=prediction, loss=loss)
+    def test_preserves_normalisation_and_bounds(self) -> None:
+        """Preserve normalisation, bounds and colourmap configuration."""
+        norm = Normalize(vmin=-1.0, vmax=1.0)
 
-    assert output.loss is loss
+        spec = DiffColourmapSpec(norm=norm, vmin=None, vmax=None, cmap="coolwarm")
+
+        assert spec.norm is norm
+        assert spec.vmin is None
+        assert spec.vmax is None
+        assert spec.cmap == "coolwarm"
 
 
-def test_uncertainty_arrays_preserve_named_tuple_fields() -> None:
-    """Preserve array identities and tuple ordering for uncertainty values."""
-    ground_truth = np.zeros((2, 3), dtype=np.float32)
-    prediction = np.ones((2, 3), dtype=np.float32)
-    uncertainty = np.full((2, 3), 0.1, dtype=np.float32)
+class TestMetadata:
+    """Tests for Metadata."""
 
-    arrays = UncertaintyArrays(
-        ground_truth=ground_truth,
-        prediction=prediction,
-        uncertainty=uncertainty,
-    )
+    def test_accepts_training_summary_fields(self) -> None:
+        """Accept and preserve training-summary metadata fields."""
+        metadata = Metadata(
+            model="cnn-vit-cnn",
+            max_epochs=20,
+            current_epoch=7,
+            start="2017-01-01",
+            end="2019-12-31",
+            cadence="24h",
+            n_points=1095,
+            n_history_steps=3,
+            vars_by_source={"sic-ssmis": ["ice_conc"]},
+        )
 
-    assert arrays.ground_truth is ground_truth
-    assert arrays.prediction is prediction
-    assert arrays.uncertainty is uncertainty
-    assert arrays[0] is ground_truth
-    assert arrays[1] is prediction
-    assert arrays[2] is uncertainty
+        assert metadata.model == "cnn-vit-cnn"
+        assert metadata.current_epoch == 7
+        assert metadata.n_history_steps == 3
+        assert metadata.vars_by_source == {"sic-ssmis": ["ice_conc"]}
+
+    def test_defaults_are_independent_and_optional(self) -> None:
+        """Keep Metadata defaults optional and independent across instances."""
+        first = Metadata()
+        second = Metadata()
+
+        first.vars_by_source = {"era5": ["2t"]}
+
+        assert first.model is None
+        assert first.n_points is None
+        assert second.vars_by_source is None
+
+
+class TestProcessorOutput:
+    """Tests for ProcessorOutput."""
+
+    def test_defaults_loss_to_none(self) -> None:
+        """Default ProcessorOutput loss to None when omitted."""
+        prediction = torch.randn(2, 3, 4, 5, 6)
+
+        output = ProcessorOutput(prediction=prediction)
+
+        assert output.prediction is prediction
+        assert output.loss is None
+
+    def test_keeps_custom_loss_tensor(self) -> None:
+        """Preserve an explicitly supplied ProcessorOutput loss tensor."""
+        prediction = torch.randn(1, 2, 3, 4, 5)
+        loss = torch.tensor(0.25)
+
+        output = ProcessorOutput(prediction=prediction, loss=loss)
+
+        assert output.loss is loss
+
+
+class TestUncertaintyArrays:
+    """Tests for UncertaintyArrays."""
+
+    def test_preserve_named_tuple_fields(self) -> None:
+        """Preserve array identities and tuple ordering for uncertainty values."""
+        ground_truth = np.zeros((2, 3), dtype=np.float32)
+        prediction = np.ones((2, 3), dtype=np.float32)
+        uncertainty = np.full((2, 3), 0.1, dtype=np.float32)
+
+        arrays = UncertaintyArrays(
+            ground_truth=ground_truth,
+            prediction=prediction,
+            uncertainty=uncertainty,
+        )
+
+        assert arrays.ground_truth is ground_truth
+        assert arrays.prediction is prediction
+        assert arrays.uncertainty is uncertainty
+        assert arrays[0] is ground_truth
+        assert arrays[1] is prediction
+        assert arrays[2] is uncertainty

--- a/tests/types/test_simple_datatypes.py
+++ b/tests/types/test_simple_datatypes.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 
+import numpy as np
 import torch
 from matplotlib.colors import Normalize
 
@@ -8,10 +9,12 @@ from icenet_mp.types import (
     AnemoiDatasetStatus,
     AnemoiFinaliseArgs,
     AnemoiInitArgs,
+    AnemoiInspectArgs,
     AnemoiLoadArgs,
     DiffColourmapSpec,
     Metadata,
     ProcessorOutput,
+    UncertaintyArrays,
 )
 
 
@@ -45,6 +48,23 @@ def test_anemoi_command_args_keep_expected_defaults() -> None:
     assert load.recipe is recipe
     assert finalise.command == "unused"
     assert finalise.recipe is recipe
+
+
+def test_anemoi_inspect_args_preserve_requested_flags() -> None:
+    """Preserve explicit inspect options without hidden defaults."""
+    inspect = AnemoiInspectArgs(
+        detailed=True,
+        path="dataset.zarr",
+        progress=False,
+        size=True,
+        statistics=False,
+    )
+
+    assert inspect.path == "dataset.zarr"
+    assert inspect.detailed is True
+    assert inspect.progress is False
+    assert inspect.size is True
+    assert inspect.statistics is False
 
 
 def test_diff_colourmap_spec_preserves_normalisation_and_bounds() -> None:
@@ -109,3 +129,23 @@ def test_processor_output_keeps_custom_loss_tensor() -> None:
     output = ProcessorOutput(prediction=prediction, loss=loss)
 
     assert output.loss is loss
+
+
+def test_uncertainty_arrays_preserve_named_tuple_fields() -> None:
+    """Preserve array identities and tuple ordering for uncertainty values."""
+    ground_truth = np.zeros((2, 3), dtype=np.float32)
+    prediction = np.ones((2, 3), dtype=np.float32)
+    uncertainty = np.full((2, 3), 0.1, dtype=np.float32)
+
+    arrays = UncertaintyArrays(
+        ground_truth=ground_truth,
+        prediction=prediction,
+        uncertainty=uncertainty,
+    )
+
+    assert arrays.ground_truth is ground_truth
+    assert arrays.prediction is prediction
+    assert arrays.uncertainty is uncertainty
+    assert arrays[0] is ground_truth
+    assert arrays[1] is prediction
+    assert arrays[2] is uncertainty


### PR DESCRIPTION
## Summary

Adds focused unit coverage for runtime datatypes not covered by the existing DataSpace/PlotSpec test PR:

- `AnemoiDatasetStatus`
- Anemoi cleanup/init/load/finalise argument dataclasses and their defaults
- `DiffColourmapSpec`
- `Metadata`
- `ProcessorOutput`

## Testing

- test-only change; production behaviour is unchanged
- avoids overlap with the existing DataSpace and PlotSpec coverage
- full repository CI will run when the PR is opened

Part of #62.