### PR TITLE
Add EMA and unconditional checkpoint callback tests

### DIFF
--- a/tests/callbacks/conftest.py
+++ b/tests/callbacks/conftest.py
@@ -1,16 +1,32 @@
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 from lightning import LightningModule, Trainer
 
 
+class LinearLightningModule(LightningModule):
+    """A LightningModule wrapping a single trainable Linear(2, 2) layer."""
+
+    def __init__(self) -> None:
+        """Initialise a LightningModule with one trainable layer."""
+        super().__init__()
+        self.layer = torch.nn.Linear(2, 2)
+
+
 @pytest.fixture
-def mock_trainer() -> MagicMock:
-    """A bare mock Trainer; tests configure whatever attributes they need."""
-    return MagicMock(spec=Trainer)
+def linear_lightning_module() -> LinearLightningModule:
+    """A real LightningModule with one trainable layer."""
+    return LinearLightningModule()
 
 
 @pytest.fixture
 def mock_module() -> MagicMock:
     """A bare mock LightningModule; tests configure whatever attributes they need."""
     return MagicMock(spec=LightningModule)
+
+
+@pytest.fixture
+def mock_trainer() -> MagicMock:
+    """A bare mock Trainer; tests configure whatever attributes they need."""
+    return MagicMock(spec=Trainer)

--- a/tests/callbacks/conftest.py
+++ b/tests/callbacks/conftest.py
@@ -1,0 +1,16 @@
+from unittest.mock import MagicMock
+
+import pytest
+from lightning import LightningModule, Trainer
+
+
+@pytest.fixture
+def mock_trainer() -> MagicMock:
+    """A bare mock Trainer; tests configure whatever attributes they need."""
+    return MagicMock(spec=Trainer)
+
+
+@pytest.fixture
+def mock_module() -> MagicMock:
+    """A bare mock LightningModule; tests configure whatever attributes they need."""
+    return MagicMock(spec=LightningModule)

--- a/tests/callbacks/test_activation_saver.py
+++ b/tests/callbacks/test_activation_saver.py
@@ -42,15 +42,6 @@ class MinimalRolloutModel(nn.Module):
         return self.processor(first_step)
 
 
-class MinimalLightningModule(LightningModule):
-    """Minimal LightningModule exposing a named submodule for attach() to hook."""
-
-    def __init__(self) -> None:
-        """Initialise a LightningModule with one hookable layer."""
-        super().__init__()
-        self.layer = nn.Linear(2, 2)
-
-
 class TestActivationSaver:
     def test_attach_rejects_unknown_layer(self, tmp_path: Path) -> None:
         """Reject unknown layer paths."""
@@ -160,13 +151,15 @@ class TestActivationSaver:
         saver.detach()
 
     def test_on_test_start_attaches_hooks_when_enabled(
-        self, tmp_path: Path, mock_trainer: MagicMock
+        self,
+        tmp_path: Path,
+        mock_trainer: MagicMock,
+        linear_lightning_module: LightningModule,
     ) -> None:
         """Attach hooks automatically when on_test_start runs and layers are configured."""
         saver = ActivationSaver(["layer"], tmp_path)
-        pl_module = MinimalLightningModule()
 
-        saver.on_test_start(mock_trainer, pl_module)
+        saver.on_test_start(mock_trainer, linear_lightning_module)
 
         assert len(saver._handles) > 0
         saver.detach()

--- a/tests/callbacks/test_activation_saver.py
+++ b/tests/callbacks/test_activation_saver.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
-from lightning import LightningModule, Trainer
+from lightning import LightningModule
 from torch import nn
 
 from icenet_mp.callbacks import ActivationSaver
@@ -60,14 +60,14 @@ class TestActivationSaver:
         with pytest.raises(ValueError, match="missing"):
             saver.attach(model)
 
-    def test_layer_hook_keeps_first_fire_per_batch(self, tmp_path: Path) -> None:
+    def test_layer_hook_keeps_first_fire_per_batch(
+        self, tmp_path: Path, mock_trainer: MagicMock, mock_module: MagicMock
+    ) -> None:
         """Keep only the first activation when a layer fires twice."""
         saver = ActivationSaver(["shared"], tmp_path)
         model = MinimalReusedLayerModel()
         saver.attach(model)
-        saver.on_test_batch_start(
-            MagicMock(spec=Trainer), MagicMock(spec=LightningModule), {}, 0
-        )
+        saver.on_test_batch_start(mock_trainer, mock_module, {}, 0)
 
         inputs = torch.tensor([[1.0, 3.0]])
         output = model(inputs)
@@ -76,22 +76,22 @@ class TestActivationSaver:
         assert torch.equal(saver._current_activations["shared"], 2 * inputs)
         saver.detach()
 
-    def test_batch_payload_and_metadata_are_written(self, tmp_path: Path) -> None:
+    def test_batch_payload_and_metadata_are_written(
+        self, tmp_path: Path, mock_trainer: MagicMock, mock_module: MagicMock
+    ) -> None:
         """Write batch payloads and evaluation metadata."""
         saver = ActivationSaver(["0"], tmp_path, save_inputs=True)
         model = nn.Sequential(nn.Linear(2, 2, bias=False))
         saver.attach(model)
 
-        trainer = MagicMock(spec=Trainer)
-        pl_module = MagicMock(spec=LightningModule)
         sic_batch = torch.tensor([[1.0, 2.0]])
         batch = {
             "sic": sic_batch,
             "metadata": "not-a-tensor",
         }
-        saver.on_test_batch_start(trainer, pl_module, batch, 7)
+        saver.on_test_batch_start(mock_trainer, mock_module, batch, 7)
         model(sic_batch)
-        saver.on_test_batch_end(trainer, pl_module, None, batch, 7)
+        saver.on_test_batch_end(mock_trainer, mock_module, None, batch, 7)
 
         payload_path = tmp_path / "batch_00007.pt"
         payload = torch.load(payload_path, weights_only=False)
@@ -102,7 +102,7 @@ class TestActivationSaver:
         assert set(payload["inputs"]) == {"sic"}
         assert torch.equal(payload["inputs"]["sic"], sic_batch)
 
-        saver.on_test_end(trainer, pl_module)
+        saver.on_test_end(mock_trainer, mock_module)
         metadata = json.loads((tmp_path / "metadata.json").read_text())
 
         assert metadata["layer_paths"] == ["0"]
@@ -110,30 +110,28 @@ class TestActivationSaver:
         assert metadata["batch_file_template"] == "batch_{batch_idx:05d}.pt"
         assert saver._handles == []
 
-    def test_empty_layer_list_is_disabled(self, tmp_path: Path) -> None:
+    def test_empty_layer_list_is_disabled(
+        self, tmp_path: Path, mock_trainer: MagicMock, mock_module: MagicMock
+    ) -> None:
         """Leave the callback disabled when no layers are configured."""
         output_dir = tmp_path / "activations"
         saver = ActivationSaver([], output_dir)
 
-        trainer = MagicMock(spec=Trainer)
-        pl_module = MagicMock(spec=LightningModule)
-        saver.on_test_start(trainer, pl_module)
-        saver.on_test_batch_start(trainer, pl_module, {}, 0)
-        saver.on_test_batch_end(trainer, pl_module, None, {}, 0)
-        saver.on_test_end(trainer, pl_module)
+        saver.on_test_start(mock_trainer, mock_module)
+        saver.on_test_batch_start(mock_trainer, mock_module, {}, 0)
+        saver.on_test_batch_end(mock_trainer, mock_module, None, {}, 0)
+        saver.on_test_end(mock_trainer, mock_module)
 
         assert not output_dir.exists()
 
     def test_processor_rollout_counter_keeps_first_step_only(
-        self, tmp_path: Path
+        self, tmp_path: Path, mock_trainer: MagicMock, mock_module: MagicMock
     ) -> None:
         """Increment the rollout counter per processor call and keep only step 0."""
         saver = ActivationSaver(["processor"], tmp_path)
         model = MinimalRolloutModel()
         saver.attach(model)
-        saver.on_test_batch_start(
-            MagicMock(spec=Trainer), MagicMock(spec=LightningModule), {}, 0
-        )
+        saver.on_test_batch_start(mock_trainer, mock_module, {}, 0)
 
         inputs = torch.tensor([[1.0, 3.0]])
         model(inputs)
@@ -142,29 +140,50 @@ class TestActivationSaver:
         saver.detach()
 
     def test_batch_end_warns_about_uncaptured_layers(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+        self,
+        tmp_path: Path,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn when a configured layer never fired its hook this batch."""
         saver = ActivationSaver(["0"], tmp_path)
         model = nn.Sequential(nn.Linear(2, 2))
         saver.attach(model)
 
-        trainer = MagicMock(spec=Trainer)
-        pl_module = MagicMock(spec=LightningModule)
-        saver.on_test_batch_start(trainer, pl_module, {}, 0)
+        saver.on_test_batch_start(mock_trainer, mock_module, {}, 0)
         # The model is never called, so "0"'s forward hook never fires.
         with caplog.at_level(logging.WARNING):
-            saver.on_test_batch_end(trainer, pl_module, None, {}, 0)
+            saver.on_test_batch_end(mock_trainer, mock_module, None, {}, 0)
 
         assert "no activation captured for layers ['0']" in caplog.text
         saver.detach()
 
-    def test_on_test_start_attaches_hooks_when_enabled(self, tmp_path: Path) -> None:
+    def test_on_test_start_attaches_hooks_when_enabled(
+        self, tmp_path: Path, mock_trainer: MagicMock
+    ) -> None:
         """Attach hooks automatically when on_test_start runs and layers are configured."""
         saver = ActivationSaver(["layer"], tmp_path)
         pl_module = MinimalLightningModule()
 
-        saver.on_test_start(MagicMock(spec=Trainer), pl_module)
+        saver.on_test_start(mock_trainer, pl_module)
 
         assert len(saver._handles) > 0
         saver.detach()
+
+    def test_detach_stops_capturing_new_activations(
+        self, tmp_path: Path, mock_trainer: MagicMock, mock_module: MagicMock
+    ) -> None:
+        """Stop capturing activations once the hooks have been detached."""
+        saver = ActivationSaver(["shared"], tmp_path)
+        model = MinimalReusedLayerModel()
+        saver.attach(model)
+        saver.on_test_batch_start(mock_trainer, mock_module, {}, 0)
+        model(torch.tensor([[1.0, 3.0]]))
+        assert saver._current_activations
+
+        saver.detach()
+        saver._current_activations = {}
+        model(torch.tensor([[1.0, 3.0]]))
+
+        assert saver._current_activations == {}

--- a/tests/callbacks/test_ema_and_checkpoint_callbacks.py
+++ b/tests/callbacks/test_ema_and_checkpoint_callbacks.py
@@ -1,0 +1,124 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from lightning.pytorch.callbacks import WeightAveraging
+
+from icenet_mp.callbacks.ema_weight_averaging_callback import EMAWeightAveragingCallback
+from icenet_mp.callbacks.unconditional_checkpoint import UnconditionalCheckpoint
+
+
+@pytest.mark.parametrize(
+    ("step_idx", "epoch_idx", "expected"),
+    [
+        (2, None, False),
+        (3, None, True),
+        (6, None, True),
+        (None, 1, False),
+        (None, 2, True),
+        (None, 4, True),
+        (None, None, False),
+    ],
+)
+def test_ema_should_update_on_configured_interval(
+    step_idx: int | None, epoch_idx: int | None, *, expected: bool
+) -> None:
+    callback = EMAWeightAveragingCallback(
+        decay_rate=0.99,
+        every_n_steps=3,
+        every_n_epochs=2,
+    )
+
+    assert callback.should_update(step_idx=step_idx, epoch_idx=epoch_idx) is expected
+
+
+def test_ema_batch_hook_skips_parameterless_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
+    parent_hook = MagicMock()
+    monkeypatch.setattr(WeightAveraging, "on_train_batch_end", parent_hook)
+    module = torch.nn.Identity()
+
+    callback.on_train_batch_end(MagicMock(), module)
+
+    parent_hook.assert_not_called()
+
+
+def test_ema_hooks_delegate_for_parameterised_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
+    batch_hook = MagicMock()
+    epoch_hook = MagicMock()
+    monkeypatch.setattr(WeightAveraging, "on_train_batch_end", batch_hook)
+    monkeypatch.setattr(WeightAveraging, "on_train_epoch_end", epoch_hook)
+    module = torch.nn.Linear(2, 2)
+    trainer = MagicMock()
+
+    callback.on_train_batch_end(trainer, module)
+    callback.on_train_epoch_end(trainer, module)
+
+    batch_hook.assert_called_once()
+    epoch_hook.assert_called_once()
+
+
+def test_unconditional_checkpoint_dirpath_roundtrip(tmp_path: Path) -> None:
+    callback = UnconditionalCheckpoint()
+
+    callback.dirpath = tmp_path
+
+    assert callback.dirpath == tmp_path
+
+
+def test_unconditional_checkpoint_uses_log_dir_and_broadcast(tmp_path: Path) -> None:
+    callback = UnconditionalCheckpoint()
+    callback.impl.format_checkpoint_name = MagicMock(return_value="epoch=2-step=7.ckpt")
+    trainer = MagicMock()
+    trainer.current_epoch = 2
+    trainer.global_step = 7
+    trainer.log_dir = str(tmp_path)
+    trainer.strategy.broadcast.side_effect = lambda value: value
+
+    callback.save_unconditionally(trainer)
+
+    callback.impl.format_checkpoint_name.assert_called_once()
+    expected = tmp_path / "epoch=2-step=7.ckpt"
+    trainer.strategy.broadcast.assert_called_once_with(str(expected))
+    trainer.save_checkpoint.assert_called_once_with(expected)
+
+
+def test_unconditional_checkpoint_prefers_explicit_dirpath(tmp_path: Path) -> None:
+    callback = UnconditionalCheckpoint()
+    explicit = tmp_path / "checkpoints"
+    callback.dirpath = explicit
+    callback.impl.format_checkpoint_name = MagicMock(return_value="last.ckpt")
+    trainer = MagicMock()
+    trainer.current_epoch = 0
+    trainer.global_step = 0
+    trainer.log_dir = str(tmp_path / "logs")
+    trainer.strategy.broadcast.side_effect = lambda value: value
+
+    callback.save_unconditionally(trainer)
+
+    trainer.save_checkpoint.assert_called_once_with(explicit / "last.ckpt")
+
+
+def test_unconditional_checkpoint_train_end_is_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer = MagicMock()
+    module = MagicMock()
+
+    disabled = UnconditionalCheckpoint(on_train_end=False)
+    disabled_save = MagicMock()
+    monkeypatch.setattr(disabled, "save_unconditionally", disabled_save)
+    disabled.on_train_end(trainer, module)
+    disabled_save.assert_not_called()
+
+    enabled = UnconditionalCheckpoint(on_train_end=True)
+    enabled_save = MagicMock()
+    monkeypatch.setattr(enabled, "save_unconditionally", enabled_save)
+    enabled.on_train_end(trainer, module)
+    enabled_save.assert_called_once_with(trainer)

--- a/tests/callbacks/test_ema_weight_averaging_callback.py
+++ b/tests/callbacks/test_ema_weight_averaging_callback.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
-from lightning.pytorch import LightningModule, Trainer
+from lightning.pytorch import LightningModule
 from lightning.pytorch.callbacks import WeightAveraging
 
 from icenet_mp.callbacks.ema_weight_averaging_callback import EMAWeightAveragingCallback
@@ -37,74 +37,75 @@ class TestInit:
 class TestOnTrainBatchEnd:
     """Tests for on_train_batch_end."""
 
-    def test_skips_parameterless_module(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_skips_parameterless_module(
+        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Do not delegate to the parent hook when the module has no parameters."""
         callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
         parent_hook = MagicMock()
         monkeypatch.setattr(WeightAveraging, "on_train_batch_end", parent_hook)
         module = ParameterlessLightningModule()
 
-        callback.on_train_batch_end(MagicMock(spec=Trainer), module)
+        callback.on_train_batch_end(mock_trainer, module)
 
         parent_hook.assert_not_called()
 
     def test_delegates_for_parameterised_module(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Delegate to the parent hook when the module has parameters."""
         callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
         parent_hook = MagicMock()
         monkeypatch.setattr(WeightAveraging, "on_train_batch_end", parent_hook)
         module = LinearLightningModule()
-        trainer = MagicMock(spec=Trainer)
 
-        callback.on_train_batch_end(trainer, module)
+        callback.on_train_batch_end(mock_trainer, module)
 
         parent_hook.assert_called_once()
 
     def test_forwards_args_and_kwargs_to_parent_hook(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Forward positional and keyword arguments to the parent hook unchanged."""
         callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
         parent_hook = MagicMock()
         monkeypatch.setattr(WeightAveraging, "on_train_batch_end", parent_hook)
         module = LinearLightningModule()
-        trainer = MagicMock(spec=Trainer)
         batch = {"sic": torch.zeros(1)}
 
-        callback.on_train_batch_end(trainer, module, batch, 5, unused=True)
+        callback.on_train_batch_end(mock_trainer, module, batch, 5, unused=True)
 
-        parent_hook.assert_called_once_with(trainer, module, batch, 5, unused=True)
+        parent_hook.assert_called_once_with(mock_trainer, module, batch, 5, unused=True)
 
 
 class TestOnTrainEpochEnd:
     """Tests for on_train_epoch_end."""
 
-    def test_skips_parameterless_module(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_skips_parameterless_module(
+        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Do not delegate to the parent hook when the module has no parameters."""
         callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_epochs=1)
         parent_hook = MagicMock()
         monkeypatch.setattr(WeightAveraging, "on_train_epoch_end", parent_hook)
         module = ParameterlessLightningModule()
 
-        callback.on_train_epoch_end(MagicMock(spec=Trainer), module)
+        callback.on_train_epoch_end(mock_trainer, module)
 
         parent_hook.assert_not_called()
 
     def test_delegates_for_parameterised_module(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Delegate to the parent hook when the module has parameters."""
         callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_epochs=1)
         parent_hook = MagicMock()
         monkeypatch.setattr(WeightAveraging, "on_train_epoch_end", parent_hook)
         module = LinearLightningModule()
-        trainer = MagicMock(spec=Trainer)
 
-        callback.on_train_epoch_end(trainer, module)
+        callback.on_train_epoch_end(mock_trainer, module)
 
-        parent_hook.assert_called_once_with(trainer, module)
+        parent_hook.assert_called_once_with(mock_trainer, module)
 
 
 class TestShouldUpdate:

--- a/tests/callbacks/test_ema_weight_averaging_callback.py
+++ b/tests/callbacks/test_ema_weight_averaging_callback.py
@@ -1,64 +1,154 @@
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 import torch
+from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.callbacks import WeightAveraging
 
 from icenet_mp.callbacks.ema_weight_averaging_callback import EMAWeightAveragingCallback
-from icenet_mp.callbacks.unconditional_checkpoint import UnconditionalCheckpoint
 
 
-@pytest.mark.parametrize(
-    ("step_idx", "epoch_idx", "expected"),
-    [
-        (2, None, False),
-        (3, None, True),
-        (6, None, True),
-        (None, 1, False),
-        (None, 2, True),
-        (None, 4, True),
-        (None, None, False),
-    ],
-)
-def test_ema_should_update_on_configured_interval(
-    step_idx: int | None, epoch_idx: int | None, *, expected: bool
-) -> None:
-    callback = EMAWeightAveragingCallback(
-        decay_rate=0.99,
-        every_n_steps=3,
-        every_n_epochs=2,
+class ParameterlessLightningModule(LightningModule):
+    """A LightningModule with no parameters, to exercise the empty-module guard."""
+
+
+class LinearLightningModule(LightningModule):
+    """A LightningModule wrapping a single trainable layer."""
+
+    def __init__(self) -> None:
+        """Initialise a LightningModule with one trainable layer."""
+        super().__init__()
+        self.layer = torch.nn.Linear(2, 2)
+
+
+class TestInit:
+    """Tests for EMAWeightAveragingCallback construction."""
+
+    def test_stores_schedule_parameters(self) -> None:
+        """Store the configured update schedule on the instance."""
+        callback = EMAWeightAveragingCallback(
+            decay_rate=0.99, every_n_epochs=2, every_n_steps=3
+        )
+
+        assert callback.every_n_epochs == 2
+        assert callback.every_n_steps == 3
+
+
+class TestOnTrainBatchEnd:
+    """Tests for on_train_batch_end."""
+
+    def test_skips_parameterless_module(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Do not delegate to the parent hook when the module has no parameters."""
+        callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
+        parent_hook = MagicMock()
+        monkeypatch.setattr(WeightAveraging, "on_train_batch_end", parent_hook)
+        module = ParameterlessLightningModule()
+
+        callback.on_train_batch_end(MagicMock(spec=Trainer), module)
+
+        parent_hook.assert_not_called()
+
+    def test_delegates_for_parameterised_module(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Delegate to the parent hook when the module has parameters."""
+        callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
+        parent_hook = MagicMock()
+        monkeypatch.setattr(WeightAveraging, "on_train_batch_end", parent_hook)
+        module = LinearLightningModule()
+        trainer = MagicMock(spec=Trainer)
+
+        callback.on_train_batch_end(trainer, module)
+
+        parent_hook.assert_called_once()
+
+    def test_forwards_args_and_kwargs_to_parent_hook(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Forward positional and keyword arguments to the parent hook unchanged."""
+        callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
+        parent_hook = MagicMock()
+        monkeypatch.setattr(WeightAveraging, "on_train_batch_end", parent_hook)
+        module = LinearLightningModule()
+        trainer = MagicMock(spec=Trainer)
+        batch = {"sic": torch.zeros(1)}
+
+        callback.on_train_batch_end(trainer, module, batch, 5, unused=True)
+
+        parent_hook.assert_called_once_with(trainer, module, batch, 5, unused=True)
+
+
+class TestOnTrainEpochEnd:
+    """Tests for on_train_epoch_end."""
+
+    def test_skips_parameterless_module(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Do not delegate to the parent hook when the module has no parameters."""
+        callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_epochs=1)
+        parent_hook = MagicMock()
+        monkeypatch.setattr(WeightAveraging, "on_train_epoch_end", parent_hook)
+        module = ParameterlessLightningModule()
+
+        callback.on_train_epoch_end(MagicMock(spec=Trainer), module)
+
+        parent_hook.assert_not_called()
+
+    def test_delegates_for_parameterised_module(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Delegate to the parent hook when the module has parameters."""
+        callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_epochs=1)
+        parent_hook = MagicMock()
+        monkeypatch.setattr(WeightAveraging, "on_train_epoch_end", parent_hook)
+        module = LinearLightningModule()
+        trainer = MagicMock(spec=Trainer)
+
+        callback.on_train_epoch_end(trainer, module)
+
+        parent_hook.assert_called_once_with(trainer, module)
+
+
+class TestShouldUpdate:
+    """Tests for should_update."""
+
+    @pytest.mark.parametrize(
+        ("step_idx", "epoch_idx", "expected"),
+        [
+            (2, None, False),
+            (3, None, True),
+            (6, None, True),
+            (None, 1, False),
+            (None, 2, True),
+            (None, 4, True),
+            (None, None, False),
+            (0, None, False),
+            (None, 0, False),
+            (3, 1, False),
+            (4, 2, True),
+        ],
+        ids=[
+            "step-not-multiple",
+            "step-multiple",
+            "step-multiple-x2",
+            "epoch-not-multiple",
+            "epoch-multiple",
+            "epoch-multiple-x2",
+            "neither-given",
+            "step-zero",
+            "epoch-zero",
+            "both-given-epoch-not-multiple-wins",
+            "both-given-epoch-multiple-wins",
+        ],
     )
+    def test_updates_on_configured_interval(
+        self, step_idx: int | None, epoch_idx: int | None, *, expected: bool
+    ) -> None:
+        """Update on the configured step/epoch interval, epoch taking precedence."""
+        callback = EMAWeightAveragingCallback(
+            decay_rate=0.99,
+            every_n_steps=3,
+            every_n_epochs=2,
+        )
 
-    assert callback.should_update(step_idx=step_idx, epoch_idx=epoch_idx) is expected
-
-
-def test_ema_batch_hook_skips_parameterless_module(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
-    parent_hook = MagicMock()
-    monkeypatch.setattr(WeightAveraging, "on_train_batch_end", parent_hook)
-    module = torch.nn.Identity()
-
-    callback.on_train_batch_end(MagicMock(), module)
-
-    parent_hook.assert_not_called()
-
-
-def test_ema_hooks_delegate_for_parameterised_module(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
-    batch_hook = MagicMock()
-    epoch_hook = MagicMock()
-    monkeypatch.setattr(WeightAveraging, "on_train_batch_end", batch_hook)
-    monkeypatch.setattr(WeightAveraging, "on_train_epoch_end", epoch_hook)
-    module = torch.nn.Linear(2, 2)
-    trainer = MagicMock()
-
-    callback.on_train_batch_end(trainer, module)
-    callback.on_train_epoch_end(trainer, module)
-
-    batch_hook.assert_called_once()
-    epoch_hook.assert_called_once()
+        assert (
+            callback.should_update(step_idx=step_idx, epoch_idx=epoch_idx) is expected
+        )

--- a/tests/callbacks/test_ema_weight_averaging_callback.py
+++ b/tests/callbacks/test_ema_weight_averaging_callback.py
@@ -12,15 +12,6 @@ class ParameterlessLightningModule(LightningModule):
     """A LightningModule with no parameters, to exercise the empty-module guard."""
 
 
-class LinearLightningModule(LightningModule):
-    """A LightningModule wrapping a single trainable layer."""
-
-    def __init__(self) -> None:
-        """Initialise a LightningModule with one trainable layer."""
-        super().__init__()
-        self.layer = torch.nn.Linear(2, 2)
-
-
 class TestInit:
     """Tests for EMAWeightAveragingCallback construction."""
 
@@ -51,26 +42,32 @@ class TestOnTrainBatchEnd:
         parent_hook.assert_not_called()
 
     def test_delegates_for_parameterised_module(
-        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        linear_lightning_module: LightningModule,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Delegate to the parent hook when the module has parameters."""
         callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
         parent_hook = MagicMock()
         monkeypatch.setattr(WeightAveraging, "on_train_batch_end", parent_hook)
-        module = LinearLightningModule()
+        module = linear_lightning_module
 
         callback.on_train_batch_end(mock_trainer, module)
 
         parent_hook.assert_called_once()
 
     def test_forwards_args_and_kwargs_to_parent_hook(
-        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        linear_lightning_module: LightningModule,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Forward positional and keyword arguments to the parent hook unchanged."""
         callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
         parent_hook = MagicMock()
         monkeypatch.setattr(WeightAveraging, "on_train_batch_end", parent_hook)
-        module = LinearLightningModule()
+        module = linear_lightning_module
         batch = {"sic": torch.zeros(1)}
 
         callback.on_train_batch_end(mock_trainer, module, batch, 5, unused=True)
@@ -95,13 +92,16 @@ class TestOnTrainEpochEnd:
         parent_hook.assert_not_called()
 
     def test_delegates_for_parameterised_module(
-        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        linear_lightning_module: LightningModule,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Delegate to the parent hook when the module has parameters."""
         callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_epochs=1)
         parent_hook = MagicMock()
         monkeypatch.setattr(WeightAveraging, "on_train_epoch_end", parent_hook)
-        module = LinearLightningModule()
+        module = linear_lightning_module
 
         callback.on_train_epoch_end(mock_trainer, module)
 

--- a/tests/callbacks/test_ema_weight_averaging_callback.py
+++ b/tests/callbacks/test_ema_weight_averaging_callback.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from lightning.pytorch.callbacks import WeightAveraging
+
+from icenet_mp.callbacks.ema_weight_averaging_callback import EMAWeightAveragingCallback
+from icenet_mp.callbacks.unconditional_checkpoint import UnconditionalCheckpoint
+
+
+@pytest.mark.parametrize(
+    ("step_idx", "epoch_idx", "expected"),
+    [
+        (2, None, False),
+        (3, None, True),
+        (6, None, True),
+        (None, 1, False),
+        (None, 2, True),
+        (None, 4, True),
+        (None, None, False),
+    ],
+)
+def test_ema_should_update_on_configured_interval(
+    step_idx: int | None, epoch_idx: int | None, *, expected: bool
+) -> None:
+    callback = EMAWeightAveragingCallback(
+        decay_rate=0.99,
+        every_n_steps=3,
+        every_n_epochs=2,
+    )
+
+    assert callback.should_update(step_idx=step_idx, epoch_idx=epoch_idx) is expected
+
+
+def test_ema_batch_hook_skips_parameterless_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
+    parent_hook = MagicMock()
+    monkeypatch.setattr(WeightAveraging, "on_train_batch_end", parent_hook)
+    module = torch.nn.Identity()
+
+    callback.on_train_batch_end(MagicMock(), module)
+
+    parent_hook.assert_not_called()
+
+
+def test_ema_hooks_delegate_for_parameterised_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
+    batch_hook = MagicMock()
+    epoch_hook = MagicMock()
+    monkeypatch.setattr(WeightAveraging, "on_train_batch_end", batch_hook)
+    monkeypatch.setattr(WeightAveraging, "on_train_epoch_end", epoch_hook)
+    module = torch.nn.Linear(2, 2)
+    trainer = MagicMock()
+
+    callback.on_train_batch_end(trainer, module)
+    callback.on_train_epoch_end(trainer, module)
+
+    batch_hook.assert_called_once()
+    epoch_hook.assert_called_once()

--- a/tests/callbacks/test_metric_summary_callback.py
+++ b/tests/callbacks/test_metric_summary_callback.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
-from lightning import LightningModule, Trainer
+from lightning import Trainer
 from lightning.pytorch.loggers import WandbLogger
 from lightning.pytorch.trainer.states import TrainerFn
 from torchmetrics import MeanAbsoluteError, MetricCollection
@@ -24,18 +24,16 @@ def callback() -> MetricSummaryCallback:
 
 @pytest.fixture
 def mock_trainer() -> MagicMock:
-    """Create a mock Trainer."""
+    """A mock Trainer with sanity checking off and one plain logger.
+
+    Overrides the bare tests/callbacks/conftest.py fixture of the same name: most tests
+    in this file need a non-W&B logger already in place to assert on.
+    """
     trainer = MagicMock(spec=Trainer)
     trainer.sanity_checking = False
     mock_logger = MagicMock()
     trainer.loggers = [mock_logger]
     return trainer
-
-
-@pytest.fixture
-def mock_module() -> MagicMock:
-    """Create a mock LightningModule."""
-    return MagicMock(spec=LightningModule)
 
 
 class TestOnTestEnd:
@@ -270,41 +268,47 @@ class TestEpochStartResets:
     """Tests for the on_*_epoch_start metric-reset hooks."""
 
     def test_on_test_epoch_start_resets_test_metrics(
-        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
+        self,
+        callback: MetricSummaryCallback,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
     ) -> None:
         """Reset test_metrics at the start of a test epoch."""
         metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
         metric_collection.update(torch.zeros(1), torch.ones(1))
-        pl_module = MagicMock(spec=LightningModule)
-        pl_module.test_metrics = metric_collection
+        mock_module.test_metrics = metric_collection
 
-        callback.on_test_epoch_start(mock_trainer, pl_module)
+        callback.on_test_epoch_start(mock_trainer, mock_module)
 
         assert metric_collection["mae"]._update_called is False
 
     def test_on_train_epoch_start_resets_train_metrics(
-        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
+        self,
+        callback: MetricSummaryCallback,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
     ) -> None:
         """Reset train_metrics at the start of a training epoch."""
         metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
         metric_collection.update(torch.zeros(1), torch.ones(1))
-        pl_module = MagicMock(spec=LightningModule)
-        pl_module.train_metrics = metric_collection
+        mock_module.train_metrics = metric_collection
 
-        callback.on_train_epoch_start(mock_trainer, pl_module)
+        callback.on_train_epoch_start(mock_trainer, mock_module)
 
         assert metric_collection["mae"]._update_called is False
 
     def test_on_validation_epoch_start_resets_validation_metrics(
-        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
+        self,
+        callback: MetricSummaryCallback,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
     ) -> None:
         """Reset validation_metrics at the start of a validation epoch."""
         metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
         metric_collection.update(torch.zeros(1), torch.ones(1))
-        pl_module = MagicMock(spec=LightningModule)
-        pl_module.validation_metrics = metric_collection
+        mock_module.validation_metrics = metric_collection
 
-        callback.on_validation_epoch_start(mock_trainer, pl_module)
+        callback.on_validation_epoch_start(mock_trainer, mock_module)
 
         assert metric_collection["mae"]._update_called is False
 
@@ -313,15 +317,17 @@ class TestOnTrainEpochEnd:
     """Tests for on_train_epoch_end."""
 
     def test_logs_when_train_metrics_present(
-        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
+        self,
+        callback: MetricSummaryCallback,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
     ) -> None:
         """Log per-epoch metrics when train_metrics is a MetricCollection."""
         metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
         metric_collection.update(torch.zeros(1), torch.ones(1))
-        pl_module = MagicMock(spec=LightningModule)
-        pl_module.train_metrics = metric_collection
+        mock_module.train_metrics = metric_collection
 
-        callback.on_train_epoch_end(mock_trainer, pl_module)
+        callback.on_train_epoch_end(mock_trainer, mock_module)
 
         mock_logger = mock_trainer.loggers[0]
         mock_logger.log_metrics.assert_called_once()
@@ -330,14 +336,14 @@ class TestOnTrainEpochEnd:
         self,
         callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
+        mock_module: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn when train_metrics is not a MetricCollection."""
-        pl_module = MagicMock(spec=LightningModule)
-        pl_module.train_metrics = "invalid"
+        mock_module.train_metrics = "invalid"
 
         with caplog.at_level(logging.WARNING):
-            callback.on_train_epoch_end(mock_trainer, pl_module)
+            callback.on_train_epoch_end(mock_trainer, mock_module)
 
         assert "Could not load train metrics!" in caplog.text
 
@@ -346,15 +352,17 @@ class TestOnValidationEpochEnd:
     """Tests for on_validation_epoch_end."""
 
     def test_logs_when_validation_metrics_present(
-        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
+        self,
+        callback: MetricSummaryCallback,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
     ) -> None:
         """Log per-epoch metrics when validation_metrics is a MetricCollection."""
         metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
         metric_collection.update(torch.zeros(1), torch.ones(1))
-        pl_module = MagicMock(spec=LightningModule)
-        pl_module.validation_metrics = metric_collection
+        mock_module.validation_metrics = metric_collection
 
-        callback.on_validation_epoch_end(mock_trainer, pl_module)
+        callback.on_validation_epoch_end(mock_trainer, mock_module)
 
         mock_logger = mock_trainer.loggers[0]
         mock_logger.log_metrics.assert_called_once()
@@ -363,14 +371,14 @@ class TestOnValidationEpochEnd:
         self,
         callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
+        mock_module: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn when validation_metrics is not a MetricCollection."""
-        pl_module = MagicMock(spec=LightningModule)
-        pl_module.validation_metrics = "invalid"
+        mock_module.validation_metrics = "invalid"
 
         with caplog.at_level(logging.WARNING):
-            callback.on_validation_epoch_end(mock_trainer, pl_module)
+            callback.on_validation_epoch_end(mock_trainer, mock_module)
 
         assert "Could not load validation metrics!" in caplog.text
 
@@ -382,16 +390,16 @@ class TestTeardown:
         self,
         callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
+        mock_module: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Gather both train and validation metrics for a fit run."""
-        pl_module = MagicMock(spec=LightningModule)
-        pl_module.train_metrics = MetricCollection({"mae": MeanAbsoluteError()})
-        pl_module.validation_metrics = MetricCollection({"mae": MeanAbsoluteError()})
+        mock_module.train_metrics = MetricCollection({"mae": MeanAbsoluteError()})
+        mock_module.validation_metrics = MetricCollection({"mae": MeanAbsoluteError()})
         mock_log_per_run_metrics = MagicMock()
         monkeypatch.setattr(callback, "log_per_run_metrics", mock_log_per_run_metrics)
 
-        callback.teardown(mock_trainer, pl_module, stage=TrainerFn.FITTING.value)
+        callback.teardown(mock_trainer, mock_module, stage=TrainerFn.FITTING.value)
 
         mock_log_per_run_metrics.assert_called_once()
         metrics = mock_log_per_run_metrics.call_args[0][1]
@@ -401,15 +409,15 @@ class TestTeardown:
         self,
         callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
+        mock_module: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn for each stage whose metrics collection is missing during a fit run."""
-        pl_module = MagicMock(spec=LightningModule)
-        pl_module.train_metrics = "invalid"
-        pl_module.validation_metrics = "invalid"
+        mock_module.train_metrics = "invalid"
+        mock_module.validation_metrics = "invalid"
 
         with caplog.at_level(logging.WARNING):
-            callback.teardown(mock_trainer, pl_module, stage=TrainerFn.FITTING.value)
+            callback.teardown(mock_trainer, mock_module, stage=TrainerFn.FITTING.value)
 
         assert "Could not load train metrics!" in caplog.text
         assert "Could not load validation metrics!" in caplog.text
@@ -418,16 +426,23 @@ class TestTeardown:
         self,
         callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
+        mock_module: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn when test_metrics is missing during a test run."""
-        pl_module = MagicMock(spec=LightningModule)
-        pl_module.test_metrics = "invalid"
+        mock_module.test_metrics = "invalid"
 
         with caplog.at_level(logging.WARNING):
-            callback.teardown(mock_trainer, pl_module, stage=TrainerFn.TESTING.value)
+            callback.teardown(mock_trainer, mock_module, stage=TrainerFn.TESTING.value)
 
         assert "Could not load test metrics!" in caplog.text
+
+
+def _to_5d(values_2d: list[list[float]]) -> torch.Tensor:
+    """Reshape a 4-cell x 3-day grid into (batch=1, time=3, channels=1, height=2, width=2)."""
+    return (
+        torch.tensor(values_2d).view(2, 2, 3).permute(2, 0, 1).unsqueeze(0).unsqueeze(2)
+    )
 
 
 class TestMetricCalculations:
@@ -443,17 +458,12 @@ class TestMetricCalculations:
 
     def test_calculates_mean_mae_daily_correctly(self) -> None:
         """Test that MAE daily is calculated correctly."""
-        # Convert 2D tensor to 5D tensor: (batch, channels, height, width, time)
-        preds_2d = torch.tensor(
+        preds = _to_5d(
             [[1.0, 2.0, 4.0], [1.0, 3.0, 4.0], [2.0, 3.0, 5.0], [2.0, 4.0, 6.0]]
         )
-        targets_2d = torch.tensor(
+        targets = _to_5d(
             [[1.5, 2.5, 4.0], [0.5, 3.5, 4.0], [2.0, 4.0, 5.0], [2.5, 3.0, 6.0]]
         )
-
-        # Reshape to 5D: (batch=1, time=3, channels=1, height=2, width=2)
-        preds = preds_2d.view(2, 2, 3).permute(2, 0, 1).unsqueeze(0).unsqueeze(2)
-        targets = targets_2d.view(2, 2, 3).permute(2, 0, 1).unsqueeze(0).unsqueeze(2)
 
         computed_mae = MAEPerForecastDay()
         computed_mae.update(preds, targets)
@@ -470,16 +480,12 @@ class TestMetricCalculations:
 
     def test_calculates_mean_rmse_daily_correctly(self) -> None:
         """Test that RMSE daily is calculated correctly."""
-        preds_2d = torch.tensor(
+        preds = _to_5d(
             [[1.0, 2.0, 4.0], [1.0, 3.0, 4.0], [2.0, 3.0, 5.0], [2.0, 4.0, 6.0]]
         )
-        targets_2d = torch.tensor(
+        targets = _to_5d(
             [[1.5, 2.5, 4.0], [0.5, 3.5, 4.0], [2.0, 4.0, 5.0], [2.5, 3.0, 6.0]]
         )
-
-        # Reshape to 5D: (batch=1, time=3, channels=1, height=2, width=2)
-        preds = preds_2d.view(2, 2, 3).permute(2, 0, 1).unsqueeze(0).unsqueeze(2)
-        targets = targets_2d.view(2, 2, 3).permute(2, 0, 1).unsqueeze(0).unsqueeze(2)
 
         computed_rmse = RMSEPerForecastDay()
         computed_rmse.update(preds, targets)
@@ -497,16 +503,12 @@ class TestMetricCalculations:
 
     def test_calculates_mean_sieerror_daily_correctly(self) -> None:
         """Test that SIEError daily is calculated correctly."""
-        preds_2d = torch.tensor(
+        preds = _to_5d(
             [[0.0, 0.1, 0.8], [0.1, 0.2, 0.3], [0.3, 0.4, 0.5], [0.0, 0.1, 0.0]]
         )
-        targets_2d = torch.tensor(
+        targets = _to_5d(
             [[0.3, 0.5, 0.1], [0.6, 0.1, 0.0], [0.9, 0.9, 0.9], [0.0, 0.0, 1.0]]
         )
-
-        # Reshape to 5D: (batch=1, time=3, channels=1, height=2, width=2)
-        preds = preds_2d.view(2, 2, 3).permute(2, 0, 1).unsqueeze(0).unsqueeze(2)
-        targets = targets_2d.view(2, 2, 3).permute(2, 0, 1).unsqueeze(0).unsqueeze(2)
 
         computed_sie = SeaIceExtentErrorPerForecastDay(pixel_size=1)
         computed_sie.update(preds, targets)
@@ -524,16 +526,12 @@ class TestMetricCalculations:
 
     def test_calculates_mean_sieerror_daily_pixel_size(self) -> None:
         """Test that SIEError daily is calculated correctly."""
-        preds_2d = torch.tensor(
+        preds = _to_5d(
             [[0.0, 0.1, 0.8], [0.1, 0.2, 0.3], [0.3, 0.4, 0.5], [0.0, 0.1, 0.0]]
         )
-        targets_2d = torch.tensor(
+        targets = _to_5d(
             [[0.3, 0.5, 0.1], [0.6, 0.1, 0.0], [0.9, 0.9, 0.9], [0.0, 0.0, 1.0]]
         )
-
-        # Reshape to 5D: (batch=1, time=3, channels=1, height=2, width=2)
-        preds = preds_2d.view(2, 2, 3).permute(2, 0, 1).unsqueeze(0).unsqueeze(2)
-        targets = targets_2d.view(2, 2, 3).permute(2, 0, 1).unsqueeze(0).unsqueeze(2)
 
         computed_sie = SeaIceExtentErrorPerForecastDay()
         computed_sie.update(preds, targets)

--- a/tests/callbacks/test_metric_summary_callback.py
+++ b/tests/callbacks/test_metric_summary_callback.py
@@ -17,12 +17,6 @@ from icenet_mp.metrics import (
 
 
 @pytest.fixture
-def callback() -> MetricSummaryCallback:
-    """Create a MetricSummaryCallback instance."""
-    return MetricSummaryCallback()
-
-
-@pytest.fixture
 def mock_trainer() -> MagicMock:
     """Override the default mock_trainer with sanity checking off and one plain logger."""
     trainer = MagicMock(spec=Trainer)
@@ -64,11 +58,11 @@ class TestOnTestEnd:
 
     def test_on_test_end_with_metric_collection(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         mock_module: MagicMock,
     ) -> None:
         """Test on_test_end with a valid MetricCollection."""
+        callback = MetricSummaryCallback()
         metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
         mock_module.test_metrics = metric_collection
 
@@ -86,11 +80,11 @@ class TestOnTestEnd:
 
     def test_on_test_end_with_invalid_test_metrics(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         mock_module: MagicMock,
     ) -> None:
         """Test on_test_end when test_metrics is not a MetricCollection."""
+        callback = MetricSummaryCallback()
         mock_module.test_metrics = "invalid"
 
         callback.on_test_epoch_end(mock_trainer, mock_module)
@@ -101,11 +95,11 @@ class TestOnTestEnd:
 
     def test_on_test_end_with_wandb_logger_vector_metric(
         self,
-        callback: MetricSummaryCallback,
         mock_module: MagicMock,
         wandb_run: tuple[MagicMock, MockWandbRun],
     ) -> None:
         """Test on_test_end with WandbLogger and a metric returning a vector."""
+        callback = MetricSummaryCallback()
         mock_wandb, mock_run = wandb_run
 
         # Create a trainer with WandbLogger
@@ -142,11 +136,12 @@ class TestOnTestEnd:
 
     def test_on_test_end_without_wandb_logger_vector_metric(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         mock_module: MagicMock,
     ) -> None:
         """Test on_test_end with non-WandbLogger and a metric returning a vector."""
+        callback = MetricSummaryCallback()
+
         # Create a metric that returns multiple values (daily metric)
         metric_collection = MetricCollection({"mae_daily": MAEPerForecastDay()})
         mock_module.test_metrics = metric_collection
@@ -168,10 +163,9 @@ class TestOnTestEnd:
 class TestLogPerEpochMetrics:
     """Tests for log_per_epoch_metrics."""
 
-    def test_skips_during_sanity_checking(
-        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
-    ) -> None:
+    def test_skips_during_sanity_checking(self, mock_trainer: MagicMock) -> None:
         """Do not log anything while Lightning's sanity check is running."""
+        callback = MetricSummaryCallback()
         mock_trainer.sanity_checking = True
         metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
         metric_collection.update(torch.zeros(1), torch.ones(1))
@@ -182,9 +176,10 @@ class TestLogPerEpochMetrics:
         mock_logger.log_metrics.assert_not_called()
 
     def test_skips_metrics_that_were_never_updated(
-        self, callback: MetricSummaryCallback, mock_trainer: MagicMock
+        self, mock_trainer: MagicMock
     ) -> None:
         """Skip metrics in the collection whose update() was never called."""
+        callback = MetricSummaryCallback()
         metric_collection = MetricCollection(
             {"mae": MeanAbsoluteError(), "unused": MeanAbsoluteError()}
         )
@@ -204,11 +199,11 @@ class TestLogPerRunMetrics:
 
     def test_skips_during_sanity_checking(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Return before evaluating anything while Lightning's sanity check is running."""
+        callback = MetricSummaryCallback()
         mock_trainer.sanity_checking = True
 
         with caplog.at_level(logging.WARNING):
@@ -218,11 +213,11 @@ class TestLogPerRunMetrics:
 
     def test_warns_and_skips_without_wandb_logger(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn and skip logging when no WandbLogger/run is available."""
+        callback = MetricSummaryCallback()
         with caplog.at_level(logging.WARNING):
             callback.log_per_run_metrics(mock_trainer, {})
 
@@ -230,11 +225,11 @@ class TestLogPerRunMetrics:
 
     def test_skips_metrics_that_were_never_updated(
         self,
-        callback: MetricSummaryCallback,
         wandb_run: tuple[MagicMock, MockWandbRun],
     ) -> None:
         """Skip metrics whose update() was never called when building the per-day plot."""
-        mock_wandb, _mock_run = wandb_run
+        callback = MetricSummaryCallback()
+        mock_wandb, _ = wandb_run
 
         trainer = MagicMock(spec=Trainer)
         trainer.sanity_checking = False
@@ -258,11 +253,11 @@ class TestEpochStartResets:
 
     def test_on_test_epoch_start_resets_test_metrics(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         mock_module: MagicMock,
     ) -> None:
         """Reset test_metrics at the start of a test epoch."""
+        callback = MetricSummaryCallback()
         metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
         metric_collection.update(torch.zeros(1), torch.ones(1))
         mock_module.test_metrics = metric_collection
@@ -273,11 +268,11 @@ class TestEpochStartResets:
 
     def test_on_train_epoch_start_resets_train_metrics(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         mock_module: MagicMock,
     ) -> None:
         """Reset train_metrics at the start of a training epoch."""
+        callback = MetricSummaryCallback()
         metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
         metric_collection.update(torch.zeros(1), torch.ones(1))
         mock_module.train_metrics = metric_collection
@@ -288,11 +283,11 @@ class TestEpochStartResets:
 
     def test_on_validation_epoch_start_resets_validation_metrics(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         mock_module: MagicMock,
     ) -> None:
         """Reset validation_metrics at the start of a validation epoch."""
+        callback = MetricSummaryCallback()
         metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
         metric_collection.update(torch.zeros(1), torch.ones(1))
         mock_module.validation_metrics = metric_collection
@@ -307,11 +302,11 @@ class TestOnTrainEpochEnd:
 
     def test_logs_when_train_metrics_present(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         mock_module: MagicMock,
     ) -> None:
         """Log per-epoch metrics when train_metrics is a MetricCollection."""
+        callback = MetricSummaryCallback()
         metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
         metric_collection.update(torch.zeros(1), torch.ones(1))
         mock_module.train_metrics = metric_collection
@@ -323,12 +318,12 @@ class TestOnTrainEpochEnd:
 
     def test_warns_when_train_metrics_missing(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         mock_module: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn when train_metrics is not a MetricCollection."""
+        callback = MetricSummaryCallback()
         mock_module.train_metrics = "invalid"
 
         with caplog.at_level(logging.WARNING):
@@ -342,11 +337,11 @@ class TestOnValidationEpochEnd:
 
     def test_logs_when_validation_metrics_present(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         mock_module: MagicMock,
     ) -> None:
         """Log per-epoch metrics when validation_metrics is a MetricCollection."""
+        callback = MetricSummaryCallback()
         metric_collection = MetricCollection({"mae": MeanAbsoluteError()})
         metric_collection.update(torch.zeros(1), torch.ones(1))
         mock_module.validation_metrics = metric_collection
@@ -358,12 +353,12 @@ class TestOnValidationEpochEnd:
 
     def test_warns_when_validation_metrics_missing(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         mock_module: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn when validation_metrics is not a MetricCollection."""
+        callback = MetricSummaryCallback()
         mock_module.validation_metrics = "invalid"
 
         with caplog.at_level(logging.WARNING):
@@ -377,12 +372,12 @@ class TestTeardown:
 
     def test_fitting_stage_collects_train_and_validation_metrics(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         mock_module: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Gather both train and validation metrics for a fit run."""
+        callback = MetricSummaryCallback()
         mock_module.train_metrics = MetricCollection({"mae": MeanAbsoluteError()})
         mock_module.validation_metrics = MetricCollection({"mae": MeanAbsoluteError()})
         mock_log_per_run_metrics = MagicMock()
@@ -396,12 +391,12 @@ class TestTeardown:
 
     def test_fitting_stage_warns_when_metrics_missing(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         mock_module: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn for each stage whose metrics collection is missing during a fit run."""
+        callback = MetricSummaryCallback()
         mock_module.train_metrics = "invalid"
         mock_module.validation_metrics = "invalid"
 
@@ -413,12 +408,12 @@ class TestTeardown:
 
     def test_testing_stage_warns_when_test_metrics_missing(
         self,
-        callback: MetricSummaryCallback,
         mock_trainer: MagicMock,
         mock_module: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn when test_metrics is missing during a test run."""
+        callback = MetricSummaryCallback()
         mock_module.test_metrics = "invalid"
 
         with caplog.at_level(logging.WARNING):
@@ -427,15 +422,19 @@ class TestTeardown:
         assert "Could not load test metrics!" in caplog.text
 
 
-def _to_5d(values_2d: list[list[float]]) -> torch.Tensor:
-    """Reshape a 4-cell x 3-day grid into (batch=1, time=3, channels=1, height=2, width=2)."""
-    return (
-        torch.tensor(values_2d).view(2, 2, 3).permute(2, 0, 1).unsqueeze(0).unsqueeze(2)
-    )
-
-
 class TestMetricCalculations:
     """Tests for per-forecast-day metric calculation correctness."""
+
+    @staticmethod
+    def to_5d(values_2d: list[list[float]]) -> torch.Tensor:
+        """Reshape a 4-cell x 3-day grid into (batch=1, time=3, channels=1, height=2, width=2)."""
+        return (
+            torch.tensor(values_2d)
+            .view(2, 2, 3)
+            .permute(2, 0, 1)
+            .unsqueeze(0)
+            .unsqueeze(2)
+        )
 
     def test_accumulates_multiple_batches(self) -> None:
         """Accumulate daily errors across batches with matching lead times."""
@@ -447,10 +446,10 @@ class TestMetricCalculations:
 
     def test_calculates_mean_mae_daily_correctly(self) -> None:
         """Test that MAE daily is calculated correctly."""
-        preds = _to_5d(
+        preds = self.to_5d(
             [[1.0, 2.0, 4.0], [1.0, 3.0, 4.0], [2.0, 3.0, 5.0], [2.0, 4.0, 6.0]]
         )
-        targets = _to_5d(
+        targets = self.to_5d(
             [[1.5, 2.5, 4.0], [0.5, 3.5, 4.0], [2.0, 4.0, 5.0], [2.5, 3.0, 6.0]]
         )
 
@@ -469,10 +468,10 @@ class TestMetricCalculations:
 
     def test_calculates_mean_rmse_daily_correctly(self) -> None:
         """Test that RMSE daily is calculated correctly."""
-        preds = _to_5d(
+        preds = self.to_5d(
             [[1.0, 2.0, 4.0], [1.0, 3.0, 4.0], [2.0, 3.0, 5.0], [2.0, 4.0, 6.0]]
         )
-        targets = _to_5d(
+        targets = self.to_5d(
             [[1.5, 2.5, 4.0], [0.5, 3.5, 4.0], [2.0, 4.0, 5.0], [2.5, 3.0, 6.0]]
         )
 
@@ -492,10 +491,10 @@ class TestMetricCalculations:
 
     def test_calculates_mean_sieerror_daily_correctly(self) -> None:
         """Test that SIEError daily is calculated correctly."""
-        preds = _to_5d(
+        preds = self.to_5d(
             [[0.0, 0.1, 0.8], [0.1, 0.2, 0.3], [0.3, 0.4, 0.5], [0.0, 0.1, 0.0]]
         )
-        targets = _to_5d(
+        targets = self.to_5d(
             [[0.3, 0.5, 0.1], [0.6, 0.1, 0.0], [0.9, 0.9, 0.9], [0.0, 0.0, 1.0]]
         )
 
@@ -515,10 +514,10 @@ class TestMetricCalculations:
 
     def test_calculates_mean_sieerror_daily_pixel_size(self) -> None:
         """Test that SIEError daily is calculated correctly."""
-        preds = _to_5d(
+        preds = self.to_5d(
             [[0.0, 0.1, 0.8], [0.1, 0.2, 0.3], [0.3, 0.4, 0.5], [0.0, 0.1, 0.0]]
         )
-        targets = _to_5d(
+        targets = self.to_5d(
             [[0.3, 0.5, 0.1], [0.6, 0.1, 0.0], [0.9, 0.9, 0.9], [0.0, 0.0, 1.0]]
         )
 
@@ -530,10 +529,7 @@ class TestMetricCalculations:
         # Day 1: sie error = |0-1 + 0-1 + 1-1 + 0-0| * 1^2 = 2.0
         # Day 2: sie error = |0-1 + 1-0 + 1-1 + 0-0| * 1^2 = 0.0
         # Day 3: sie error = |1-0 + 1-0 + 1-1 + 0-1| * 1^2 = 1.0
-        expected_sie = torch.tensor(
-            [1250.0, 0.0, 625.0]
-        )  # default pixel_size=25 -> scaled by 25^2
-
+        # Scale factor is default pixel_size^2 = 625
+        expected_sie = torch.tensor([1250.0, 0.0, 625.0])
         assert torch.allclose(daily_result, expected_sie, atol=1e-5)
-
         assert daily_result.mean().item() == pytest.approx(625.0, abs=1e-5)

--- a/tests/callbacks/test_metric_summary_callback.py
+++ b/tests/callbacks/test_metric_summary_callback.py
@@ -24,16 +24,39 @@ def callback() -> MetricSummaryCallback:
 
 @pytest.fixture
 def mock_trainer() -> MagicMock:
-    """A mock Trainer with sanity checking off and one plain logger.
-
-    Overrides the bare tests/callbacks/conftest.py fixture of the same name: most tests
-    in this file need a non-W&B logger already in place to assert on.
-    """
+    """Override the default mock_trainer with sanity checking off and one plain logger."""
     trainer = MagicMock(spec=Trainer)
     trainer.sanity_checking = False
     mock_logger = MagicMock()
     trainer.loggers = [mock_logger]
     return trainer
+
+
+class MockWandbRun:
+    """A stand-in for a live W&B run that records .log() calls."""
+
+    def __init__(self) -> None:
+        """Initialise the mock run with a MagicMock log method."""
+        self.log = MagicMock()
+
+
+@pytest.fixture
+def wandb_run(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, MockWandbRun]:
+    """Mock the wandb module and get_wandb_run to return a working MockWandbRun.
+
+    Used by the two tests that need W&B to look "present" with a run whose .log() calls
+    can be asserted on; both duplicated this wiring verbatim before this fixture existed.
+    """
+    mock_wandb = MagicMock()
+    mock_wandb.Run = MockWandbRun
+    mock_run = MockWandbRun()
+    mock_get_wandb_run = MagicMock(return_value=mock_run)
+    monkeypatch.setattr("icenet_mp.callbacks.metric_summary_callback.wandb", mock_wandb)
+    monkeypatch.setattr(
+        "icenet_mp.callbacks.metric_summary_callback.get_wandb_run",
+        mock_get_wandb_run,
+    )
+    return mock_wandb, mock_run
 
 
 class TestOnTestEnd:
@@ -80,35 +103,16 @@ class TestOnTestEnd:
         self,
         callback: MetricSummaryCallback,
         mock_module: MagicMock,
-        monkeypatch: pytest.MonkeyPatch,
+        wandb_run: tuple[MagicMock, MockWandbRun],
     ) -> None:
         """Test on_test_end with WandbLogger and a metric returning a vector."""
-        mock_wandb = MagicMock()
-        mock_get_wandb_run = MagicMock()
-        monkeypatch.setattr(
-            "icenet_mp.callbacks.metric_summary_callback.wandb", mock_wandb
-        )
-        monkeypatch.setattr(
-            "icenet_mp.callbacks.metric_summary_callback.get_wandb_run",
-            mock_get_wandb_run,
-        )
-
-        # Mock wandb.Run for isinstance check
-        class MockWandbRun:
-            def __init__(self) -> None:
-                self.log = MagicMock()
-
-        mock_wandb.Run = MockWandbRun
+        mock_wandb, mock_run = wandb_run
 
         # Create a trainer with WandbLogger
         trainer = MagicMock(spec=Trainer)
         trainer.sanity_checking = False
         wandb_logger = MagicMock(spec=WandbLogger)
         trainer.loggers = [wandb_logger]
-
-        # Mock get_wandb_run to return a MockWandbRun instance
-        mock_run = MockWandbRun()
-        mock_get_wandb_run.return_value = mock_run
 
         # Create a metric that returns multiple values (daily metric)
         metric_collection = MetricCollection({"mae_daily": MAEPerForecastDay()})
@@ -227,25 +231,10 @@ class TestLogPerRunMetrics:
     def test_skips_metrics_that_were_never_updated(
         self,
         callback: MetricSummaryCallback,
-        monkeypatch: pytest.MonkeyPatch,
+        wandb_run: tuple[MagicMock, MockWandbRun],
     ) -> None:
         """Skip metrics whose update() was never called when building the per-day plot."""
-        mock_wandb = MagicMock()
-        mock_get_wandb_run = MagicMock()
-        monkeypatch.setattr(
-            "icenet_mp.callbacks.metric_summary_callback.wandb", mock_wandb
-        )
-        monkeypatch.setattr(
-            "icenet_mp.callbacks.metric_summary_callback.get_wandb_run",
-            mock_get_wandb_run,
-        )
-
-        class MockWandbRun:
-            def __init__(self) -> None:
-                self.log = MagicMock()
-
-        mock_wandb.Run = MockWandbRun
-        mock_get_wandb_run.return_value = MockWandbRun()
+        mock_wandb, _mock_run = wandb_run
 
         trainer = MagicMock(spec=Trainer)
         trainer.sanity_checking = False

--- a/tests/callbacks/test_plotting_callback.py
+++ b/tests/callbacks/test_plotting_callback.py
@@ -1,0 +1,653 @@
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+from lightning import LightningModule, Trainer
+from omegaconf import DictConfig
+from torch.utils.data import DataLoader
+
+from icenet_mp.callbacks.plotting_callback import PlottingCallback
+from icenet_mp.data import CombinedDataset
+from icenet_mp.models import BaseModel
+from icenet_mp.types import Metadata, ModelStepOutput
+
+
+def _make_plots_args() -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Build a minimal trainer/pl_module/dataset trio for make_plots tests."""
+    trainer = MagicMock(spec=Trainer)
+    trainer.current_epoch = 0
+    trainer.loggers = []
+    trainer.datamodule = None
+    pl_module = MagicMock(spec=BaseModel)
+    pl_module.hemisphere = "south"
+    dataset = MagicMock(spec=CombinedDataset)
+    dataset.dates = [np.datetime64("2020-01-01T12:00:00")]
+    dataset.get_forecast_steps.return_value = [np.datetime64("2020-01-01T12:00:00")]
+    dataset.inputs = []
+    return trainer, pl_module, dataset
+
+
+def _stub_plotter(
+    callback: PlottingCallback, monkeypatch: pytest.MonkeyPatch
+) -> dict[str, MagicMock]:
+    """Replace load_target_uncertainties and all Plotter output methods with spies."""
+    mocks = {
+        "load_target_uncertainties": MagicMock(return_value={}),
+        "log_static_outputs": MagicMock(),
+        "log_static_inputs": MagicMock(),
+        "log_video_outputs": MagicMock(),
+        "log_video_inputs": MagicMock(),
+        "set_hemisphere": MagicMock(),
+        "set_metadata": MagicMock(),
+    }
+    monkeypatch.setattr(
+        callback, "load_target_uncertainties", mocks["load_target_uncertainties"]
+    )
+    for name in (
+        "log_static_outputs",
+        "log_static_inputs",
+        "log_video_outputs",
+        "log_video_inputs",
+        "set_hemisphere",
+        "set_metadata",
+    ):
+        monkeypatch.setattr(callback.plotter, name, mocks[name])
+    return mocks
+
+
+class TestInit:
+    """Tests for PlottingCallback construction."""
+
+    def test_defaults_frequency_to_negative_one_when_not_given(self) -> None:
+        """Disable all frequency-based triggers when no frequency dict is given."""
+        callback = PlottingCallback()
+
+        assert callback.frequency_batch == -1
+        assert callback.frequency_epoch == -1
+        assert callback.frequency_number == -1
+
+    def test_parses_frequency_dict(self) -> None:
+        """Read batch/epoch/number frequencies from the given dict."""
+        callback = PlottingCallback(frequency={"batch": 5, "epoch": 2, "number": 3})
+
+        assert callback.frequency_batch == 5
+        assert callback.frequency_epoch == 2
+        assert callback.frequency_number == 3
+
+    def test_stores_plot_toggles_and_prefix(self) -> None:
+        """Store the plot-type toggles and key prefix as configured."""
+        callback = PlottingCallback(
+            make_input_plots=True,
+            make_static_plots=False,
+            make_video_plots=False,
+            prefix="eval",
+        )
+
+        assert callback.make_input_plots is True
+        assert callback.make_static_plots is False
+        assert callback.make_video_plots is False
+        assert callback.prefix == "eval"
+
+
+class TestCacheBatch:
+    """Tests for cache_batch."""
+
+    def test_caches_when_outputs_is_a_mapping(self) -> None:
+        """Cache batch index, dataloader index, and outputs when given a mapping."""
+        callback = PlottingCallback()
+        outputs = {
+            "prediction": torch.zeros(1, 1, 1, 2, 2),
+            "target": torch.ones(1, 1, 1, 2, 2),
+            "loss": torch.tensor(0.0),
+        }
+
+        callback.cache_batch(3, 1, outputs)
+
+        assert callback.cached_batch_idx_ == 3
+        assert callback.cached_dataloader_idx_ == 1
+        assert isinstance(callback.cached_outputs_, ModelStepOutput)
+
+    def test_does_not_cache_when_outputs_is_not_a_mapping(self) -> None:
+        """Leave the cache untouched when outputs is not a mapping."""
+        callback = PlottingCallback()
+
+        callback.cache_batch(3, 1, torch.tensor(0.0))
+
+        assert callback.cached_batch_idx_ is None
+        assert callback.cached_dataloader_idx_ is None
+        assert callback.cached_outputs_ is None
+
+
+class TestIsSampleBatch:
+    """Tests for is_sample_batch."""
+
+    def test_returns_false_when_frequency_number_not_positive(self) -> None:
+        """Never select a batch when sampling is disabled."""
+        callback = PlottingCallback(frequency={"number": 0})
+
+        assert callback.is_sample_batch(0, 10) is False
+
+    @pytest.mark.parametrize(
+        "total_batches", [float("inf"), float("nan")], ids=["inf", "nan"]
+    )
+    def test_returns_false_when_total_batches_not_finite(
+        self, total_batches: float
+    ) -> None:
+        """Never select a batch when the total batch count is not finite."""
+        callback = PlottingCallback(frequency={"number": 3})
+
+        assert callback.is_sample_batch(0, total_batches) is False
+
+    def test_returns_false_when_total_batches_not_positive(self) -> None:
+        """Never select a batch when there are no batches to sample from."""
+        callback = PlottingCallback(frequency={"number": 3})
+
+        assert callback.is_sample_batch(0, 0) is False
+
+    def test_single_target_selects_last_batch(self) -> None:
+        """Sample only the final batch when frequency_number resolves to one target."""
+        callback = PlottingCallback(frequency={"number": 1})
+
+        assert callback.is_sample_batch(4, 5) is True
+        assert callback.is_sample_batch(0, 5) is False
+
+    @pytest.mark.parametrize(
+        ("batch_idx", "expected"),
+        [(0, True), (4, True), (9, True), (1, False), (5, False)],
+        ids=["first", "middle", "last", "not-first", "not-middle"],
+    )
+    def test_selects_evenly_spaced_targets(
+        self, batch_idx: int, *, expected: bool
+    ) -> None:
+        """Sample evenly-spaced batch indices across the epoch."""
+        callback = PlottingCallback(frequency={"number": 3})
+
+        assert callback.is_sample_batch(batch_idx, 10) is expected
+
+
+class TestLoadDataset:
+    """Tests for load_dataset."""
+
+    def test_returns_none_when_dataloader_is_none(self) -> None:
+        """Return None when there is no dataloader to inspect."""
+        callback = PlottingCallback()
+        callback.cached_dataloader_idx_ = 0
+
+        assert callback.load_dataset(None) is None
+
+    def test_returns_none_when_cached_dataloader_idx_is_none(self) -> None:
+        """Return None when no batch has been cached yet."""
+        callback = PlottingCallback()
+
+        assert callback.load_dataset(MagicMock(spec=DataLoader)) is None
+
+    def test_indexes_into_sequence_of_dataloaders(self) -> None:
+        """Select the dataloader at cached_dataloader_idx_ from a sequence."""
+        callback = PlottingCallback()
+        callback.cached_dataloader_idx_ = 1
+        dataset = MagicMock(spec=CombinedDataset)
+        dataloader = MagicMock(spec=DataLoader)
+        dataloader.dataset = dataset
+        dataloader.batch_size = 4
+        other_dataloader = MagicMock(spec=DataLoader)
+
+        result = callback.load_dataset([other_dataloader, dataloader])
+
+        assert result == (dataset, 4)
+
+    def test_uses_single_dataloader_directly(self) -> None:
+        """Use the dataloader directly when it is not a sequence."""
+        callback = PlottingCallback()
+        callback.cached_dataloader_idx_ = 0
+        dataset = MagicMock(spec=CombinedDataset)
+        dataloader = MagicMock(spec=DataLoader)
+        dataloader.dataset = dataset
+        dataloader.batch_size = 2
+
+        assert callback.load_dataset(dataloader) == (dataset, 2)
+
+    def test_returns_none_and_warns_when_dataset_is_not_combined_dataset(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warn and return None when the dataloader's dataset is the wrong type."""
+        callback = PlottingCallback()
+        callback.cached_dataloader_idx_ = 0
+        dataloader = MagicMock(spec=DataLoader)
+        dataloader.dataset = object()
+        dataloader.batch_size = 2
+
+        with caplog.at_level(logging.WARNING):
+            result = callback.load_dataset(dataloader)
+
+        assert result is None
+        assert "not CombinedDataset" in caplog.text
+
+    def test_returns_none_and_warns_when_batch_size_is_none(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warn and return None when the dataloader has no batch size."""
+        callback = PlottingCallback()
+        callback.cached_dataloader_idx_ = 0
+        dataloader = MagicMock(spec=DataLoader)
+        dataloader.dataset = MagicMock(spec=CombinedDataset)
+        dataloader.batch_size = None
+
+        with caplog.at_level(logging.WARNING):
+            result = callback.load_dataset(dataloader)
+
+        assert result is None
+        assert "does not have a batch size" in caplog.text
+
+
+class TestSetMetadata:
+    """Tests for set_metadata."""
+
+    def test_delegates_to_plotter_get_metadata(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Store the plotter's metadata computed from the given config and model name."""
+        callback = PlottingCallback()
+        metadata = MagicMock(spec=Metadata)
+        get_metadata = MagicMock(return_value=metadata)
+        monkeypatch.setattr(callback.plotter, "get_metadata", get_metadata)
+        config = DictConfig({"train": {}})
+
+        callback.set_metadata(config, "my_model")
+
+        get_metadata.assert_called_once_with(config, "my_model")
+        assert callback.plotter_metadata is metadata
+
+
+class TestMakePlots:
+    """Tests for make_plots."""
+
+    def test_warns_and_returns_when_no_cached_outputs(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Skip plotting entirely when no batch has been cached."""
+        callback = PlottingCallback()
+        trainer, pl_module, dataset = _make_plots_args()
+
+        with caplog.at_level(logging.WARNING):
+            callback.make_plots(trainer, pl_module, dataset, 1)
+
+        assert "Could not load outputs" in caplog.text
+
+    def test_warns_and_returns_when_pl_module_is_not_base_model(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Skip plotting when the module is not a BaseModel (no hemisphere info)."""
+        callback = PlottingCallback()
+        callback.cached_batch_idx_ = 0
+        callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
+        trainer, _pl_module, dataset = _make_plots_args()
+        pl_module = MagicMock(spec=LightningModule)
+
+        with caplog.at_level(logging.WARNING):
+            callback.make_plots(trainer, pl_module, dataset, 1)
+
+        assert "skipping plotting" in caplog.text
+
+    def test_sets_plotter_metadata_when_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Push the cached plotter_metadata (with current_epoch) onto the plotter."""
+        callback = PlottingCallback()
+        stubs = _stub_plotter(callback, monkeypatch)
+        callback.cached_batch_idx_ = 0
+        callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
+        callback.plotter_metadata = MagicMock(spec=Metadata)
+        trainer, pl_module, dataset = _make_plots_args()
+        trainer.current_epoch = 7
+
+        callback.make_plots(trainer, pl_module, dataset, 1)
+
+        assert callback.plotter_metadata.current_epoch == 7
+        stubs["set_metadata"].assert_called_once_with(callback.plotter_metadata)
+        stubs["set_hemisphere"].assert_called_once_with("south")
+
+    def test_caches_land_mask_per_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Build a LandMask once per mask directory and reuse it on repeat calls."""
+        callback = PlottingCallback()
+        _stub_plotter(callback, monkeypatch)
+        callback.cached_batch_idx_ = 0
+        callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
+        trainer, pl_module, dataset = _make_plots_args()
+        trainer.datamodule = MagicMock(mask_directory=tmp_path)
+
+        callback.make_plots(trainer, pl_module, dataset, 1)
+        first_land_mask = callback.plotter.land_mask
+        callback.make_plots(trainer, pl_module, dataset, 1)
+
+        assert callback.plotter.land_mask is first_land_mask
+        assert len(callback._land_mask_cache) == 1
+
+    def test_skips_static_and_video_plots_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Do not call any plotter output methods when both toggles are disabled."""
+        callback = PlottingCallback(make_static_plots=False, make_video_plots=False)
+        stubs = _stub_plotter(callback, monkeypatch)
+        callback.cached_batch_idx_ = 0
+        callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
+        trainer, pl_module, dataset = _make_plots_args()
+
+        callback.make_plots(trainer, pl_module, dataset, 1)
+
+        stubs["log_static_outputs"].assert_not_called()
+        stubs["log_video_outputs"].assert_not_called()
+
+    def test_makes_input_plots_when_enabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Also log static and video input plots when make_input_plots is enabled."""
+        callback = PlottingCallback(make_input_plots=True)
+        stubs = _stub_plotter(callback, monkeypatch)
+        callback.cached_batch_idx_ = 0
+        callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
+        trainer, pl_module, dataset = _make_plots_args()
+
+        callback.make_plots(trainer, pl_module, dataset, 1)
+
+        stubs["log_static_inputs"].assert_called_once()
+        stubs["log_video_inputs"].assert_called_once()
+
+    def test_filters_loggers_by_image_and_video_support(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only pass loggers with log_image/log_video to the respective plot calls."""
+        callback = PlottingCallback()
+        stubs = _stub_plotter(callback, monkeypatch)
+        callback.cached_batch_idx_ = 0
+        callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
+        trainer, pl_module, dataset = _make_plots_args()
+
+        class ImageLogger:
+            def log_image(self, *args: object, **kwargs: object) -> None: ...
+
+        class VideoLogger:
+            def log_video(self, *args: object, **kwargs: object) -> None: ...
+
+        class PlainLogger: ...
+
+        image_logger = ImageLogger()
+        video_logger = VideoLogger()
+        trainer.loggers = [image_logger, video_logger, PlainLogger()]
+
+        callback.make_plots(trainer, pl_module, dataset, 1)
+
+        assert stubs["log_static_outputs"].call_args[0][2] == [image_logger]
+        assert stubs["log_video_outputs"].call_args[0][2] == [video_logger]
+
+
+class TestOnTestBatchEnd:
+    """Tests for on_test_batch_end."""
+
+    def test_caches_and_plots_when_per_batch_frequency_matches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cache and plot when the batch index matches the configured frequency."""
+        callback = PlottingCallback(frequency={"batch": 2})
+        cache_batch = MagicMock()
+        dataset = MagicMock(spec=CombinedDataset)
+        load_dataset = MagicMock(return_value=(dataset, 2))
+        make_plots = MagicMock()
+        monkeypatch.setattr(callback, "cache_batch", cache_batch)
+        monkeypatch.setattr(callback, "load_dataset", load_dataset)
+        monkeypatch.setattr(callback, "make_plots", make_plots)
+        trainer = MagicMock(spec=Trainer)
+        trainer.is_last_batch = False
+        trainer.num_test_batches = [100]
+        pl_module = MagicMock(spec=LightningModule)
+        outputs = MagicMock()
+
+        callback.on_test_batch_end(trainer, pl_module, outputs, {}, 4, 0)
+
+        cache_batch.assert_called_once_with(4, 0, outputs)
+        load_dataset.assert_called_once_with(trainer.test_dataloaders)
+        make_plots.assert_called_once_with(trainer, pl_module, dataset, 2)
+
+    def test_caches_without_plotting_on_last_batch_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cache the final batch of the epoch but defer plotting to epoch end."""
+        callback = PlottingCallback()
+        cache_batch = MagicMock()
+        make_plots = MagicMock()
+        monkeypatch.setattr(callback, "cache_batch", cache_batch)
+        monkeypatch.setattr(callback, "make_plots", make_plots)
+        trainer = MagicMock(spec=Trainer)
+        trainer.is_last_batch = True
+        trainer.num_test_batches = [100]
+        pl_module = MagicMock(spec=LightningModule)
+        outputs = MagicMock()
+
+        callback.on_test_batch_end(trainer, pl_module, outputs, {}, 4, 0)
+
+        cache_batch.assert_called_once_with(4, 0, outputs)
+        make_plots.assert_not_called()
+
+    def test_does_nothing_when_batch_not_targeted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Skip caching entirely when the batch matches no trigger."""
+        callback = PlottingCallback()
+        cache_batch = MagicMock()
+        monkeypatch.setattr(callback, "cache_batch", cache_batch)
+        trainer = MagicMock(spec=Trainer)
+        trainer.is_last_batch = False
+        trainer.num_test_batches = [100]
+        pl_module = MagicMock(spec=LightningModule)
+
+        callback.on_test_batch_end(trainer, pl_module, MagicMock(), {}, 4, 0)
+
+        cache_batch.assert_not_called()
+
+    def test_warns_when_dataset_cannot_be_loaded(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warn and skip plotting when the dataset cannot be loaded."""
+        callback = PlottingCallback(frequency={"batch": 1})
+        monkeypatch.setattr(callback, "cache_batch", MagicMock())
+        monkeypatch.setattr(callback, "load_dataset", MagicMock(return_value=None))
+        make_plots = MagicMock()
+        monkeypatch.setattr(callback, "make_plots", make_plots)
+        trainer = MagicMock(spec=Trainer)
+        trainer.is_last_batch = False
+        trainer.num_test_batches = [100]
+        pl_module = MagicMock(spec=LightningModule)
+
+        with caplog.at_level(logging.WARNING):
+            callback.on_test_batch_end(trainer, pl_module, MagicMock(), {}, 0, 0)
+
+        assert "Could not load dataset" in caplog.text
+        make_plots.assert_not_called()
+
+
+class TestOnTestEpochEnd:
+    """Tests for on_test_epoch_end."""
+
+    def test_skips_when_frequency_epoch_negative(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Never load the dataset when epoch-based plotting is disabled."""
+        callback = PlottingCallback()
+        load_dataset = MagicMock()
+        monkeypatch.setattr(callback, "load_dataset", load_dataset)
+        trainer = MagicMock(spec=Trainer)
+        trainer.current_epoch = 5
+
+        callback.on_test_epoch_end(trainer, MagicMock(spec=LightningModule))
+
+        load_dataset.assert_not_called()
+
+    def test_skips_when_epoch_not_at_frequency(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Skip plotting on epochs that do not match the configured frequency."""
+        callback = PlottingCallback(frequency={"epoch": 2})
+        load_dataset = MagicMock()
+        monkeypatch.setattr(callback, "load_dataset", load_dataset)
+        trainer = MagicMock(spec=Trainer)
+        trainer.current_epoch = 3
+
+        callback.on_test_epoch_end(trainer, MagicMock(spec=LightningModule))
+
+        load_dataset.assert_not_called()
+
+    def test_plots_when_epoch_at_frequency(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Plot on epochs that match the configured frequency."""
+        callback = PlottingCallback(frequency={"epoch": 2})
+        dataset = MagicMock(spec=CombinedDataset)
+        monkeypatch.setattr(
+            callback, "load_dataset", MagicMock(return_value=(dataset, 2))
+        )
+        make_plots = MagicMock()
+        monkeypatch.setattr(callback, "make_plots", make_plots)
+        trainer = MagicMock(spec=Trainer)
+        trainer.current_epoch = 4
+        pl_module = MagicMock(spec=LightningModule)
+
+        callback.on_test_epoch_end(trainer, pl_module)
+
+        make_plots.assert_called_once_with(trainer, pl_module, dataset, 2)
+
+    def test_warns_when_dataset_cannot_be_loaded(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warn when the dataset cannot be loaded at epoch end."""
+        callback = PlottingCallback(frequency={"epoch": 1})
+        monkeypatch.setattr(callback, "load_dataset", MagicMock(return_value=None))
+        trainer = MagicMock(spec=Trainer)
+        trainer.current_epoch = 0
+
+        with caplog.at_level(logging.WARNING):
+            callback.on_test_epoch_end(trainer, MagicMock(spec=LightningModule))
+
+        assert "Could not load dataset" in caplog.text
+
+
+class TestOnValidationBatchEnd:
+    """Tests for on_validation_batch_end."""
+
+    def test_skips_during_sanity_checking(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ignore the initial sanity-checking run entirely."""
+        callback = PlottingCallback(frequency={"batch": 1})
+        cache_batch = MagicMock()
+        monkeypatch.setattr(callback, "cache_batch", cache_batch)
+        trainer = MagicMock(spec=Trainer)
+        trainer.sanity_checking = True
+
+        callback.on_validation_batch_end(
+            trainer, MagicMock(spec=LightningModule), MagicMock(), {}, 0, 0
+        )
+
+        cache_batch.assert_not_called()
+
+    def test_caches_and_plots_when_per_batch_frequency_matches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cache and plot when the batch index matches the configured frequency."""
+        callback = PlottingCallback(frequency={"batch": 2})
+        cache_batch = MagicMock()
+        dataset = MagicMock(spec=CombinedDataset)
+        load_dataset = MagicMock(return_value=(dataset, 3))
+        make_plots = MagicMock()
+        monkeypatch.setattr(callback, "cache_batch", cache_batch)
+        monkeypatch.setattr(callback, "load_dataset", load_dataset)
+        monkeypatch.setattr(callback, "make_plots", make_plots)
+        trainer = MagicMock(spec=Trainer)
+        trainer.sanity_checking = False
+        trainer.fit_loop = MagicMock()
+        trainer.fit_loop.epoch_loop.val_loop.batch_progress.is_last_batch = False
+        trainer.num_val_batches = [50]
+        pl_module = MagicMock(spec=LightningModule)
+        outputs = MagicMock()
+
+        callback.on_validation_batch_end(trainer, pl_module, outputs, {}, 4, 0)
+
+        cache_batch.assert_called_once_with(4, 0, outputs)
+        load_dataset.assert_called_once_with(trainer.val_dataloaders)
+        make_plots.assert_called_once_with(trainer, pl_module, dataset, 3)
+
+    def test_warns_when_dataset_cannot_be_loaded(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warn and skip plotting when the dataset cannot be loaded."""
+        callback = PlottingCallback(frequency={"batch": 1})
+        monkeypatch.setattr(callback, "cache_batch", MagicMock())
+        monkeypatch.setattr(callback, "load_dataset", MagicMock(return_value=None))
+        make_plots = MagicMock()
+        monkeypatch.setattr(callback, "make_plots", make_plots)
+        trainer = MagicMock(spec=Trainer)
+        trainer.sanity_checking = False
+        trainer.fit_loop = MagicMock()
+        trainer.fit_loop.epoch_loop.val_loop.batch_progress.is_last_batch = False
+        trainer.num_val_batches = [50]
+        pl_module = MagicMock(spec=LightningModule)
+
+        with caplog.at_level(logging.WARNING):
+            callback.on_validation_batch_end(trainer, pl_module, MagicMock(), {}, 0, 0)
+
+        assert "Could not load dataset" in caplog.text
+        make_plots.assert_not_called()
+
+
+class TestOnValidationEpochEnd:
+    """Tests for on_validation_epoch_end."""
+
+    def test_skips_when_epoch_not_at_frequency(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Skip plotting on epochs that do not match the configured frequency."""
+        callback = PlottingCallback(frequency={"epoch": 2})
+        load_dataset = MagicMock()
+        monkeypatch.setattr(callback, "load_dataset", load_dataset)
+        trainer = MagicMock(spec=Trainer)
+        trainer.current_epoch = 3
+
+        callback.on_validation_epoch_end(trainer, MagicMock(spec=LightningModule))
+
+        load_dataset.assert_not_called()
+
+    def test_plots_when_epoch_at_frequency(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Plot on epochs that match the configured frequency."""
+        callback = PlottingCallback(frequency={"epoch": 2})
+        dataset = MagicMock(spec=CombinedDataset)
+        monkeypatch.setattr(
+            callback, "load_dataset", MagicMock(return_value=(dataset, 2))
+        )
+        make_plots = MagicMock()
+        monkeypatch.setattr(callback, "make_plots", make_plots)
+        trainer = MagicMock(spec=Trainer)
+        trainer.current_epoch = 4
+        pl_module = MagicMock(spec=LightningModule)
+
+        callback.on_validation_epoch_end(trainer, pl_module)
+
+        make_plots.assert_called_once_with(trainer, pl_module, dataset, 2)
+
+    def test_warns_when_dataset_cannot_be_loaded(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warn when the dataset cannot be loaded at epoch end."""
+        callback = PlottingCallback(frequency={"epoch": 1})
+        monkeypatch.setattr(callback, "load_dataset", MagicMock(return_value=None))
+        trainer = MagicMock(spec=Trainer)
+        trainer.current_epoch = 0
+
+        with caplog.at_level(logging.WARNING):
+            callback.on_validation_epoch_end(trainer, MagicMock(spec=LightningModule))
+
+        assert "Could not load dataset" in caplog.text

--- a/tests/callbacks/test_plotting_callback.py
+++ b/tests/callbacks/test_plotting_callback.py
@@ -14,18 +14,19 @@ from icenet_mp.models import BaseModel
 from icenet_mp.types import Metadata, ModelStepOutput
 
 
-def _make_plots_args(trainer: MagicMock) -> tuple[MagicMock, MagicMock, MagicMock]:
-    """Configure a trainer and build a matching pl_module/dataset pair for make_plots tests."""
-    trainer.current_epoch = 0
-    trainer.loggers = []
-    trainer.datamodule = None
+@pytest.fixture
+def make_plots_args(mock_trainer: MagicMock) -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Configure mock_trainer and build a matching pl_module/dataset pair for make_plots tests."""
+    mock_trainer.current_epoch = 0
+    mock_trainer.loggers = []
+    mock_trainer.datamodule = None
     pl_module = MagicMock(spec=BaseModel)
     pl_module.hemisphere = "south"
     dataset = MagicMock(spec=CombinedDataset)
     dataset.dates = [np.datetime64("2020-01-01T12:00:00")]
     dataset.get_forecast_steps.return_value = [np.datetime64("2020-01-01T12:00:00")]
     dataset.inputs = []
-    return trainer, pl_module, dataset
+    return mock_trainer, pl_module, dataset
 
 
 def _stub_plotter(
@@ -263,11 +264,13 @@ class TestMakePlots:
     """Tests for make_plots."""
 
     def test_warns_and_returns_when_no_cached_outputs(
-        self, mock_trainer: MagicMock, caplog: pytest.LogCaptureFixture
+        self,
+        make_plots_args: tuple[MagicMock, MagicMock, MagicMock],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Skip plotting entirely when no batch has been cached."""
         callback = PlottingCallback()
-        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
+        trainer, pl_module, dataset = make_plots_args
 
         with caplog.at_level(logging.WARNING):
             callback.make_plots(trainer, pl_module, dataset, 1)
@@ -276,7 +279,7 @@ class TestMakePlots:
 
     def test_warns_and_returns_when_pl_module_is_not_base_model(
         self,
-        mock_trainer: MagicMock,
+        make_plots_args: tuple[MagicMock, MagicMock, MagicMock],
         mock_module: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
@@ -284,7 +287,7 @@ class TestMakePlots:
         callback = PlottingCallback()
         callback.cached_batch_idx_ = 0
         callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
-        trainer, _pl_module, dataset = _make_plots_args(mock_trainer)
+        trainer, _pl_module, dataset = make_plots_args
 
         with caplog.at_level(logging.WARNING):
             callback.make_plots(trainer, mock_module, dataset, 1)
@@ -292,7 +295,9 @@ class TestMakePlots:
         assert "skipping plotting" in caplog.text
 
     def test_sets_plotter_metadata_when_present(
-        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
+        self,
+        make_plots_args: tuple[MagicMock, MagicMock, MagicMock],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Push the cached plotter_metadata (with current_epoch) onto the plotter."""
         callback = PlottingCallback()
@@ -300,7 +305,7 @@ class TestMakePlots:
         callback.cached_batch_idx_ = 0
         callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
         callback.plotter_metadata = MagicMock(spec=Metadata)
-        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
+        trainer, pl_module, dataset = make_plots_args
         trainer.current_epoch = 7
 
         callback.make_plots(trainer, pl_module, dataset, 1)
@@ -310,14 +315,16 @@ class TestMakePlots:
         stubs["set_hemisphere"].assert_called_once_with("south")
 
     def test_selects_start_date_using_batch_size_and_cached_batch_idx(
-        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
+        self,
+        make_plots_args: tuple[MagicMock, MagicMock, MagicMock],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Index into dataset.dates using batch_size * cached_batch_idx_, not just 0."""
         callback = PlottingCallback()
         _stub_plotter(callback, monkeypatch)
         callback.cached_batch_idx_ = 2
         callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
-        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
+        trainer, pl_module, dataset = make_plots_args
         dataset.dates = [
             np.datetime64(f"2020-01-{day:02d}T12:00:00") for day in range(1, 10)
         ]
@@ -327,14 +334,17 @@ class TestMakePlots:
         dataset.get_forecast_steps.assert_called_once_with(dataset.dates[6])
 
     def test_caches_land_mask_per_path(
-        self, tmp_path: Path, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: Path,
+        make_plots_args: tuple[MagicMock, MagicMock, MagicMock],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Build a LandMask once per mask directory and reuse it on repeat calls."""
         callback = PlottingCallback()
         _stub_plotter(callback, monkeypatch)
         callback.cached_batch_idx_ = 0
         callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
-        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
+        trainer, pl_module, dataset = make_plots_args
         trainer.datamodule = MagicMock(mask_directory=tmp_path)
 
         callback.make_plots(trainer, pl_module, dataset, 1)
@@ -345,14 +355,16 @@ class TestMakePlots:
         assert len(callback._land_mask_cache) == 1
 
     def test_skips_static_and_video_plots_when_disabled(
-        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
+        self,
+        make_plots_args: tuple[MagicMock, MagicMock, MagicMock],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Do not call any plotter output methods when both toggles are disabled."""
         callback = PlottingCallback(make_static_plots=False, make_video_plots=False)
         stubs = _stub_plotter(callback, monkeypatch)
         callback.cached_batch_idx_ = 0
         callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
-        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
+        trainer, pl_module, dataset = make_plots_args
 
         callback.make_plots(trainer, pl_module, dataset, 1)
 
@@ -360,14 +372,16 @@ class TestMakePlots:
         stubs["log_video_outputs"].assert_not_called()
 
     def test_makes_input_plots_when_enabled(
-        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
+        self,
+        make_plots_args: tuple[MagicMock, MagicMock, MagicMock],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Also log static and video input plots when make_input_plots is enabled."""
         callback = PlottingCallback(make_input_plots=True)
         stubs = _stub_plotter(callback, monkeypatch)
         callback.cached_batch_idx_ = 0
         callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
-        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
+        trainer, pl_module, dataset = make_plots_args
 
         callback.make_plots(trainer, pl_module, dataset, 1)
 
@@ -375,14 +389,16 @@ class TestMakePlots:
         stubs["log_video_inputs"].assert_called_once()
 
     def test_filters_loggers_by_image_and_video_support(
-        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
+        self,
+        make_plots_args: tuple[MagicMock, MagicMock, MagicMock],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Only pass loggers with log_image/log_video to the respective plot calls."""
         callback = PlottingCallback()
         stubs = _stub_plotter(callback, monkeypatch)
         callback.cached_batch_idx_ = 0
         callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
-        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
+        trainer, pl_module, dataset = make_plots_args
 
         class ImageLogger:
             def log_image(self, *args: object, **kwargs: object) -> None: ...

--- a/tests/callbacks/test_plotting_callback.py
+++ b/tests/callbacks/test_plotting_callback.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 import torch
-from lightning import LightningModule, Trainer
 from omegaconf import DictConfig
 from torch.utils.data import DataLoader
 
@@ -15,9 +14,8 @@ from icenet_mp.models import BaseModel
 from icenet_mp.types import Metadata, ModelStepOutput
 
 
-def _make_plots_args() -> tuple[MagicMock, MagicMock, MagicMock]:
-    """Build a minimal trainer/pl_module/dataset trio for make_plots tests."""
-    trainer = MagicMock(spec=Trainer)
+def _make_plots_args(trainer: MagicMock) -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Configure a trainer and build a matching pl_module/dataset pair for make_plots tests."""
     trainer.current_epoch = 0
     trainer.loggers = []
     trainer.datamodule = None
@@ -265,11 +263,11 @@ class TestMakePlots:
     """Tests for make_plots."""
 
     def test_warns_and_returns_when_no_cached_outputs(
-        self, caplog: pytest.LogCaptureFixture
+        self, mock_trainer: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Skip plotting entirely when no batch has been cached."""
         callback = PlottingCallback()
-        trainer, pl_module, dataset = _make_plots_args()
+        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
 
         with caplog.at_level(logging.WARNING):
             callback.make_plots(trainer, pl_module, dataset, 1)
@@ -277,22 +275,24 @@ class TestMakePlots:
         assert "Could not load outputs" in caplog.text
 
     def test_warns_and_returns_when_pl_module_is_not_base_model(
-        self, caplog: pytest.LogCaptureFixture
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Skip plotting when the module is not a BaseModel (no hemisphere info)."""
         callback = PlottingCallback()
         callback.cached_batch_idx_ = 0
         callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
-        trainer, _pl_module, dataset = _make_plots_args()
-        pl_module = MagicMock(spec=LightningModule)
+        trainer, _pl_module, dataset = _make_plots_args(mock_trainer)
 
         with caplog.at_level(logging.WARNING):
-            callback.make_plots(trainer, pl_module, dataset, 1)
+            callback.make_plots(trainer, mock_module, dataset, 1)
 
         assert "skipping plotting" in caplog.text
 
     def test_sets_plotter_metadata_when_present(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Push the cached plotter_metadata (with current_epoch) onto the plotter."""
         callback = PlottingCallback()
@@ -300,7 +300,7 @@ class TestMakePlots:
         callback.cached_batch_idx_ = 0
         callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
         callback.plotter_metadata = MagicMock(spec=Metadata)
-        trainer, pl_module, dataset = _make_plots_args()
+        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
         trainer.current_epoch = 7
 
         callback.make_plots(trainer, pl_module, dataset, 1)
@@ -309,15 +309,32 @@ class TestMakePlots:
         stubs["set_metadata"].assert_called_once_with(callback.plotter_metadata)
         stubs["set_hemisphere"].assert_called_once_with("south")
 
+    def test_selects_start_date_using_batch_size_and_cached_batch_idx(
+        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Index into dataset.dates using batch_size * cached_batch_idx_, not just 0."""
+        callback = PlottingCallback()
+        _stub_plotter(callback, monkeypatch)
+        callback.cached_batch_idx_ = 2
+        callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
+        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
+        dataset.dates = [
+            np.datetime64(f"2020-01-{day:02d}T12:00:00") for day in range(1, 10)
+        ]
+
+        callback.make_plots(trainer, pl_module, dataset, 3)
+
+        dataset.get_forecast_steps.assert_called_once_with(dataset.dates[6])
+
     def test_caches_land_mask_per_path(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Build a LandMask once per mask directory and reuse it on repeat calls."""
         callback = PlottingCallback()
         _stub_plotter(callback, monkeypatch)
         callback.cached_batch_idx_ = 0
         callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
-        trainer, pl_module, dataset = _make_plots_args()
+        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
         trainer.datamodule = MagicMock(mask_directory=tmp_path)
 
         callback.make_plots(trainer, pl_module, dataset, 1)
@@ -328,14 +345,14 @@ class TestMakePlots:
         assert len(callback._land_mask_cache) == 1
 
     def test_skips_static_and_video_plots_when_disabled(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Do not call any plotter output methods when both toggles are disabled."""
         callback = PlottingCallback(make_static_plots=False, make_video_plots=False)
         stubs = _stub_plotter(callback, monkeypatch)
         callback.cached_batch_idx_ = 0
         callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
-        trainer, pl_module, dataset = _make_plots_args()
+        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
 
         callback.make_plots(trainer, pl_module, dataset, 1)
 
@@ -343,14 +360,14 @@ class TestMakePlots:
         stubs["log_video_outputs"].assert_not_called()
 
     def test_makes_input_plots_when_enabled(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Also log static and video input plots when make_input_plots is enabled."""
         callback = PlottingCallback(make_input_plots=True)
         stubs = _stub_plotter(callback, monkeypatch)
         callback.cached_batch_idx_ = 0
         callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
-        trainer, pl_module, dataset = _make_plots_args()
+        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
 
         callback.make_plots(trainer, pl_module, dataset, 1)
 
@@ -358,14 +375,14 @@ class TestMakePlots:
         stubs["log_video_inputs"].assert_called_once()
 
     def test_filters_loggers_by_image_and_video_support(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Only pass loggers with log_image/log_video to the respective plot calls."""
         callback = PlottingCallback()
         stubs = _stub_plotter(callback, monkeypatch)
         callback.cached_batch_idx_ = 0
         callback.cached_outputs_ = MagicMock(spec=ModelStepOutput)
-        trainer, pl_module, dataset = _make_plots_args()
+        trainer, pl_module, dataset = _make_plots_args(mock_trainer)
 
         class ImageLogger:
             def log_image(self, *args: object, **kwargs: object) -> None: ...
@@ -389,7 +406,10 @@ class TestOnTestBatchEnd:
     """Tests for on_test_batch_end."""
 
     def test_caches_and_plots_when_per_batch_frequency_matches(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Cache and plot when the batch index matches the configured frequency."""
         callback = PlottingCallback(frequency={"batch": 2})
@@ -400,20 +420,21 @@ class TestOnTestBatchEnd:
         monkeypatch.setattr(callback, "cache_batch", cache_batch)
         monkeypatch.setattr(callback, "load_dataset", load_dataset)
         monkeypatch.setattr(callback, "make_plots", make_plots)
-        trainer = MagicMock(spec=Trainer)
-        trainer.is_last_batch = False
-        trainer.num_test_batches = [100]
-        pl_module = MagicMock(spec=LightningModule)
+        mock_trainer.is_last_batch = False
+        mock_trainer.num_test_batches = [100]
         outputs = MagicMock()
 
-        callback.on_test_batch_end(trainer, pl_module, outputs, {}, 4, 0)
+        callback.on_test_batch_end(mock_trainer, mock_module, outputs, {}, 4, 0)
 
         cache_batch.assert_called_once_with(4, 0, outputs)
-        load_dataset.assert_called_once_with(trainer.test_dataloaders)
-        make_plots.assert_called_once_with(trainer, pl_module, dataset, 2)
+        load_dataset.assert_called_once_with(mock_trainer.test_dataloaders)
+        make_plots.assert_called_once_with(mock_trainer, mock_module, dataset, 2)
 
     def test_caches_without_plotting_on_last_batch_only(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Cache the final batch of the epoch but defer plotting to epoch end."""
         callback = PlottingCallback()
@@ -421,35 +442,38 @@ class TestOnTestBatchEnd:
         make_plots = MagicMock()
         monkeypatch.setattr(callback, "cache_batch", cache_batch)
         monkeypatch.setattr(callback, "make_plots", make_plots)
-        trainer = MagicMock(spec=Trainer)
-        trainer.is_last_batch = True
-        trainer.num_test_batches = [100]
-        pl_module = MagicMock(spec=LightningModule)
+        mock_trainer.is_last_batch = True
+        mock_trainer.num_test_batches = [100]
         outputs = MagicMock()
 
-        callback.on_test_batch_end(trainer, pl_module, outputs, {}, 4, 0)
+        callback.on_test_batch_end(mock_trainer, mock_module, outputs, {}, 4, 0)
 
         cache_batch.assert_called_once_with(4, 0, outputs)
         make_plots.assert_not_called()
 
     def test_does_nothing_when_batch_not_targeted(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Skip caching entirely when the batch matches no trigger."""
         callback = PlottingCallback()
         cache_batch = MagicMock()
         monkeypatch.setattr(callback, "cache_batch", cache_batch)
-        trainer = MagicMock(spec=Trainer)
-        trainer.is_last_batch = False
-        trainer.num_test_batches = [100]
-        pl_module = MagicMock(spec=LightningModule)
+        mock_trainer.is_last_batch = False
+        mock_trainer.num_test_batches = [100]
 
-        callback.on_test_batch_end(trainer, pl_module, MagicMock(), {}, 4, 0)
+        callback.on_test_batch_end(mock_trainer, mock_module, MagicMock(), {}, 4, 0)
 
         cache_batch.assert_not_called()
 
     def test_warns_when_dataset_cannot_be_loaded(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn and skip plotting when the dataset cannot be loaded."""
         callback = PlottingCallback(frequency={"batch": 1})
@@ -457,13 +481,11 @@ class TestOnTestBatchEnd:
         monkeypatch.setattr(callback, "load_dataset", MagicMock(return_value=None))
         make_plots = MagicMock()
         monkeypatch.setattr(callback, "make_plots", make_plots)
-        trainer = MagicMock(spec=Trainer)
-        trainer.is_last_batch = False
-        trainer.num_test_batches = [100]
-        pl_module = MagicMock(spec=LightningModule)
+        mock_trainer.is_last_batch = False
+        mock_trainer.num_test_batches = [100]
 
         with caplog.at_level(logging.WARNING):
-            callback.on_test_batch_end(trainer, pl_module, MagicMock(), {}, 0, 0)
+            callback.on_test_batch_end(mock_trainer, mock_module, MagicMock(), {}, 0, 0)
 
         assert "Could not load dataset" in caplog.text
         make_plots.assert_not_called()
@@ -473,35 +495,42 @@ class TestOnTestEpochEnd:
     """Tests for on_test_epoch_end."""
 
     def test_skips_when_frequency_epoch_negative(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Never load the dataset when epoch-based plotting is disabled."""
         callback = PlottingCallback()
         load_dataset = MagicMock()
         monkeypatch.setattr(callback, "load_dataset", load_dataset)
-        trainer = MagicMock(spec=Trainer)
-        trainer.current_epoch = 5
+        mock_trainer.current_epoch = 5
 
-        callback.on_test_epoch_end(trainer, MagicMock(spec=LightningModule))
+        callback.on_test_epoch_end(mock_trainer, mock_module)
 
         load_dataset.assert_not_called()
 
     def test_skips_when_epoch_not_at_frequency(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Skip plotting on epochs that do not match the configured frequency."""
         callback = PlottingCallback(frequency={"epoch": 2})
         load_dataset = MagicMock()
         monkeypatch.setattr(callback, "load_dataset", load_dataset)
-        trainer = MagicMock(spec=Trainer)
-        trainer.current_epoch = 3
+        mock_trainer.current_epoch = 3
 
-        callback.on_test_epoch_end(trainer, MagicMock(spec=LightningModule))
+        callback.on_test_epoch_end(mock_trainer, mock_module)
 
         load_dataset.assert_not_called()
 
     def test_plots_when_epoch_at_frequency(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Plot on epochs that match the configured frequency."""
         callback = PlottingCallback(frequency={"epoch": 2})
@@ -511,25 +540,26 @@ class TestOnTestEpochEnd:
         )
         make_plots = MagicMock()
         monkeypatch.setattr(callback, "make_plots", make_plots)
-        trainer = MagicMock(spec=Trainer)
-        trainer.current_epoch = 4
-        pl_module = MagicMock(spec=LightningModule)
+        mock_trainer.current_epoch = 4
 
-        callback.on_test_epoch_end(trainer, pl_module)
+        callback.on_test_epoch_end(mock_trainer, mock_module)
 
-        make_plots.assert_called_once_with(trainer, pl_module, dataset, 2)
+        make_plots.assert_called_once_with(mock_trainer, mock_module, dataset, 2)
 
     def test_warns_when_dataset_cannot_be_loaded(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn when the dataset cannot be loaded at epoch end."""
         callback = PlottingCallback(frequency={"epoch": 1})
         monkeypatch.setattr(callback, "load_dataset", MagicMock(return_value=None))
-        trainer = MagicMock(spec=Trainer)
-        trainer.current_epoch = 0
+        mock_trainer.current_epoch = 0
 
         with caplog.at_level(logging.WARNING):
-            callback.on_test_epoch_end(trainer, MagicMock(spec=LightningModule))
+            callback.on_test_epoch_end(mock_trainer, mock_module)
 
         assert "Could not load dataset" in caplog.text
 
@@ -538,23 +568,28 @@ class TestOnValidationBatchEnd:
     """Tests for on_validation_batch_end."""
 
     def test_skips_during_sanity_checking(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Ignore the initial sanity-checking run entirely."""
         callback = PlottingCallback(frequency={"batch": 1})
         cache_batch = MagicMock()
         monkeypatch.setattr(callback, "cache_batch", cache_batch)
-        trainer = MagicMock(spec=Trainer)
-        trainer.sanity_checking = True
+        mock_trainer.sanity_checking = True
 
         callback.on_validation_batch_end(
-            trainer, MagicMock(spec=LightningModule), MagicMock(), {}, 0, 0
+            mock_trainer, mock_module, MagicMock(), {}, 0, 0
         )
 
         cache_batch.assert_not_called()
 
     def test_caches_and_plots_when_per_batch_frequency_matches(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Cache and plot when the batch index matches the configured frequency."""
         callback = PlottingCallback(frequency={"batch": 2})
@@ -565,22 +600,24 @@ class TestOnValidationBatchEnd:
         monkeypatch.setattr(callback, "cache_batch", cache_batch)
         monkeypatch.setattr(callback, "load_dataset", load_dataset)
         monkeypatch.setattr(callback, "make_plots", make_plots)
-        trainer = MagicMock(spec=Trainer)
-        trainer.sanity_checking = False
-        trainer.fit_loop = MagicMock()
-        trainer.fit_loop.epoch_loop.val_loop.batch_progress.is_last_batch = False
-        trainer.num_val_batches = [50]
-        pl_module = MagicMock(spec=LightningModule)
+        mock_trainer.sanity_checking = False
+        mock_trainer.fit_loop = MagicMock()
+        mock_trainer.fit_loop.epoch_loop.val_loop.batch_progress.is_last_batch = False
+        mock_trainer.num_val_batches = [50]
         outputs = MagicMock()
 
-        callback.on_validation_batch_end(trainer, pl_module, outputs, {}, 4, 0)
+        callback.on_validation_batch_end(mock_trainer, mock_module, outputs, {}, 4, 0)
 
         cache_batch.assert_called_once_with(4, 0, outputs)
-        load_dataset.assert_called_once_with(trainer.val_dataloaders)
-        make_plots.assert_called_once_with(trainer, pl_module, dataset, 3)
+        load_dataset.assert_called_once_with(mock_trainer.val_dataloaders)
+        make_plots.assert_called_once_with(mock_trainer, mock_module, dataset, 3)
 
     def test_warns_when_dataset_cannot_be_loaded(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn and skip plotting when the dataset cannot be loaded."""
         callback = PlottingCallback(frequency={"batch": 1})
@@ -588,15 +625,15 @@ class TestOnValidationBatchEnd:
         monkeypatch.setattr(callback, "load_dataset", MagicMock(return_value=None))
         make_plots = MagicMock()
         monkeypatch.setattr(callback, "make_plots", make_plots)
-        trainer = MagicMock(spec=Trainer)
-        trainer.sanity_checking = False
-        trainer.fit_loop = MagicMock()
-        trainer.fit_loop.epoch_loop.val_loop.batch_progress.is_last_batch = False
-        trainer.num_val_batches = [50]
-        pl_module = MagicMock(spec=LightningModule)
+        mock_trainer.sanity_checking = False
+        mock_trainer.fit_loop = MagicMock()
+        mock_trainer.fit_loop.epoch_loop.val_loop.batch_progress.is_last_batch = False
+        mock_trainer.num_val_batches = [50]
 
         with caplog.at_level(logging.WARNING):
-            callback.on_validation_batch_end(trainer, pl_module, MagicMock(), {}, 0, 0)
+            callback.on_validation_batch_end(
+                mock_trainer, mock_module, MagicMock(), {}, 0, 0
+            )
 
         assert "Could not load dataset" in caplog.text
         make_plots.assert_not_called()
@@ -606,21 +643,26 @@ class TestOnValidationEpochEnd:
     """Tests for on_validation_epoch_end."""
 
     def test_skips_when_epoch_not_at_frequency(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Skip plotting on epochs that do not match the configured frequency."""
         callback = PlottingCallback(frequency={"epoch": 2})
         load_dataset = MagicMock()
         monkeypatch.setattr(callback, "load_dataset", load_dataset)
-        trainer = MagicMock(spec=Trainer)
-        trainer.current_epoch = 3
+        mock_trainer.current_epoch = 3
 
-        callback.on_validation_epoch_end(trainer, MagicMock(spec=LightningModule))
+        callback.on_validation_epoch_end(mock_trainer, mock_module)
 
         load_dataset.assert_not_called()
 
     def test_plots_when_epoch_at_frequency(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Plot on epochs that match the configured frequency."""
         callback = PlottingCallback(frequency={"epoch": 2})
@@ -630,24 +672,25 @@ class TestOnValidationEpochEnd:
         )
         make_plots = MagicMock()
         monkeypatch.setattr(callback, "make_plots", make_plots)
-        trainer = MagicMock(spec=Trainer)
-        trainer.current_epoch = 4
-        pl_module = MagicMock(spec=LightningModule)
+        mock_trainer.current_epoch = 4
 
-        callback.on_validation_epoch_end(trainer, pl_module)
+        callback.on_validation_epoch_end(mock_trainer, mock_module)
 
-        make_plots.assert_called_once_with(trainer, pl_module, dataset, 2)
+        make_plots.assert_called_once_with(mock_trainer, mock_module, dataset, 2)
 
     def test_warns_when_dataset_cannot_be_loaded(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warn when the dataset cannot be loaded at epoch end."""
         callback = PlottingCallback(frequency={"epoch": 1})
         monkeypatch.setattr(callback, "load_dataset", MagicMock(return_value=None))
-        trainer = MagicMock(spec=Trainer)
-        trainer.current_epoch = 0
+        mock_trainer.current_epoch = 0
 
         with caplog.at_level(logging.WARNING):
-            callback.on_validation_epoch_end(trainer, MagicMock(spec=LightningModule))
+            callback.on_validation_epoch_end(mock_trainer, mock_module)
 
         assert "Could not load dataset" in caplog.text

--- a/tests/callbacks/test_plotting_uncertainty.py
+++ b/tests/callbacks/test_plotting_uncertainty.py
@@ -12,7 +12,9 @@ from icenet_mp.types import ModelStepOutput
 from icenet_mp.visualisations import DEFAULT_SIC_SPEC, Plotter
 
 
-def _dataset_with_uncertainty() -> tuple[MagicMock, MagicMock]:
+@pytest.fixture
+def dataset_with_uncertainty() -> tuple[MagicMock, MagicMock]:
+    """A dataset double with one target/uncertainty variable pair (ice_conc)."""
     dataset = MagicMock()
     target = MagicMock()
     target.name = "target"
@@ -33,9 +35,11 @@ def _dataset_with_uncertainty() -> tuple[MagicMock, MagicMock]:
 
 
 class TestLoadTargetUncertainties:
-    def test_scales_and_masks(self) -> None:
+    def test_scales_and_masks(
+        self, dataset_with_uncertainty: tuple[MagicMock, MagicMock]
+    ) -> None:
         """Scale source uncertainty to target space and mask invalid values."""
-        dataset, _ = _dataset_with_uncertainty()
+        dataset, _ = dataset_with_uncertainty
 
         result = PlottingCallback().load_target_uncertainties(
             dataset, [datetime(2026, 8, 21, tzinfo=UTC)]
@@ -51,9 +55,11 @@ class TestLoadTargetUncertainties:
             variables=["total_standard_uncertainty"], normalise=False
         )
 
-    def test_skips_missing_source(self) -> None:
+    def test_skips_missing_source(
+        self, dataset_with_uncertainty: tuple[MagicMock, MagicMock]
+    ) -> None:
         """Return no uncertainty when the matching target input is unavailable."""
-        dataset, _ = _dataset_with_uncertainty()
+        dataset, _ = dataset_with_uncertainty
         dataset.inputs[0].name = "other"
 
         result = PlottingCallback().load_target_uncertainties(
@@ -63,9 +69,11 @@ class TestLoadTargetUncertainties:
         assert result == {}
         dataset.inputs[0].subset.assert_not_called()
 
-    def test_skips_when_target_variable_not_present(self) -> None:
+    def test_skips_when_target_variable_not_present(
+        self, dataset_with_uncertainty: tuple[MagicMock, MagicMock]
+    ) -> None:
         """Skip uncertainty loading when the target variable itself isn't in the dataset."""
-        dataset, _ = _dataset_with_uncertainty()
+        dataset, _ = dataset_with_uncertainty
         dataset.target.variable_names = ["other_variable"]
 
         result = PlottingCallback().load_target_uncertainties(
@@ -75,9 +83,13 @@ class TestLoadTargetUncertainties:
         assert result == {}
         dataset.inputs[0].subset.assert_not_called()
 
-    def test_handles_data_error(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_handles_data_error(
+        self,
+        dataset_with_uncertainty: tuple[MagicMock, MagicMock],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         """Skip uncertainty plotting when the source read fails."""
-        dataset, uncertainty_ds = _dataset_with_uncertainty()
+        dataset, uncertainty_ds = dataset_with_uncertainty
         uncertainty_ds.get_tchw.side_effect = ValueError("missing uncertainty")
 
         with caplog.at_level(logging.WARNING):
@@ -88,9 +100,13 @@ class TestLoadTargetUncertainties:
         assert result == {}
         assert "Could not load target uncertainty" in caplog.text
 
-    def test_handles_missing_statistics(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_handles_missing_statistics(
+        self,
+        dataset_with_uncertainty: tuple[MagicMock, MagicMock],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         """Skip uncertainty plotting when target statistics are missing a key."""
-        dataset, _ = _dataset_with_uncertainty()
+        dataset, _ = dataset_with_uncertainty
         dataset.target.statistics = {}
 
         with caplog.at_level(logging.WARNING):
@@ -102,10 +118,12 @@ class TestLoadTargetUncertainties:
         assert "Could not load target uncertainty" in caplog.text
 
     def test_rejects_invalid_target_range(
-        self, caplog: pytest.LogCaptureFixture
+        self,
+        dataset_with_uncertainty: tuple[MagicMock, MagicMock],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Skip scaling when the target normalisation range is invalid."""
-        dataset, _ = _dataset_with_uncertainty()
+        dataset, _ = dataset_with_uncertainty
         dataset.target.statistics = {"minimum": [1.0], "maximum": [1.0]}
 
         with caplog.at_level(logging.WARNING):

--- a/tests/callbacks/test_plotting_uncertainty.py
+++ b/tests/callbacks/test_plotting_uncertainty.py
@@ -63,6 +63,18 @@ class TestLoadTargetUncertainties:
         assert result == {}
         dataset.inputs[0].subset.assert_not_called()
 
+    def test_skips_when_target_variable_not_present(self) -> None:
+        """Skip uncertainty loading when the target variable itself isn't in the dataset."""
+        dataset, _ = _dataset_with_uncertainty()
+        dataset.target.variable_names = ["other_variable"]
+
+        result = PlottingCallback().load_target_uncertainties(
+            dataset, [datetime(2026, 8, 21, tzinfo=UTC)]
+        )
+
+        assert result == {}
+        dataset.inputs[0].subset.assert_not_called()
+
     def test_handles_data_error(self, caplog: pytest.LogCaptureFixture) -> None:
         """Skip uncertainty plotting when the source read fails."""
         dataset, uncertainty_ds = _dataset_with_uncertainty()

--- a/tests/callbacks/test_unconditional_checkpoint.py
+++ b/tests/callbacks/test_unconditional_checkpoint.py
@@ -9,61 +9,6 @@ from icenet_mp.callbacks.ema_weight_averaging_callback import EMAWeightAveraging
 from icenet_mp.callbacks.unconditional_checkpoint import UnconditionalCheckpoint
 
 
-@pytest.mark.parametrize(
-    ("step_idx", "epoch_idx", "expected"),
-    [
-        (2, None, False),
-        (3, None, True),
-        (6, None, True),
-        (None, 1, False),
-        (None, 2, True),
-        (None, 4, True),
-        (None, None, False),
-    ],
-)
-def test_ema_should_update_on_configured_interval(
-    step_idx: int | None, epoch_idx: int | None, *, expected: bool
-) -> None:
-    callback = EMAWeightAveragingCallback(
-        decay_rate=0.99,
-        every_n_steps=3,
-        every_n_epochs=2,
-    )
-
-    assert callback.should_update(step_idx=step_idx, epoch_idx=epoch_idx) is expected
-
-
-def test_ema_batch_hook_skips_parameterless_module(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
-    parent_hook = MagicMock()
-    monkeypatch.setattr(WeightAveraging, "on_train_batch_end", parent_hook)
-    module = torch.nn.Identity()
-
-    callback.on_train_batch_end(MagicMock(), module)
-
-    parent_hook.assert_not_called()
-
-
-def test_ema_hooks_delegate_for_parameterised_module(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    callback = EMAWeightAveragingCallback(decay_rate=0.99, every_n_steps=1)
-    batch_hook = MagicMock()
-    epoch_hook = MagicMock()
-    monkeypatch.setattr(WeightAveraging, "on_train_batch_end", batch_hook)
-    monkeypatch.setattr(WeightAveraging, "on_train_epoch_end", epoch_hook)
-    module = torch.nn.Linear(2, 2)
-    trainer = MagicMock()
-
-    callback.on_train_batch_end(trainer, module)
-    callback.on_train_epoch_end(trainer, module)
-
-    batch_hook.assert_called_once()
-    epoch_hook.assert_called_once()
-
-
 def test_unconditional_checkpoint_dirpath_roundtrip(tmp_path: Path) -> None:
     callback = UnconditionalCheckpoint()
 

--- a/tests/callbacks/test_unconditional_checkpoint.py
+++ b/tests/callbacks/test_unconditional_checkpoint.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-from lightning import LightningModule, Trainer
 
 from icenet_mp.callbacks.unconditional_checkpoint import UnconditionalCheckpoint
 
@@ -10,21 +9,12 @@ from icenet_mp.callbacks.unconditional_checkpoint import UnconditionalCheckpoint
 class TestDirpath:
     """Tests for the dirpath property."""
 
-    def test_roundtrip(self, tmp_path: Path) -> None:
-        """Store and return a truthy dirpath unchanged."""
-        callback = UnconditionalCheckpoint()
-
-        callback.dirpath = tmp_path
-
-        assert callback.dirpath == tmp_path
-
     def test_setter_ignores_falsy_value(self, tmp_path: Path) -> None:
-        """Leave an existing dirpath unchanged when set to a falsy value."""
+        """Round-trip a truthy dirpath, and leave it unchanged when set to a falsy value."""
         callback = UnconditionalCheckpoint()
         callback.dirpath = tmp_path
-
+        assert callback.dirpath == tmp_path
         callback.dirpath = None
-
         assert callback.dirpath == tmp_path
 
 
@@ -32,7 +22,7 @@ class TestSaveUnconditionally:
     """Tests for save_unconditionally."""
 
     def test_uses_log_dir_and_broadcast(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Fall back to the trainer's log_dir and broadcast the resolved path."""
         callback = UnconditionalCheckpoint()
@@ -40,21 +30,20 @@ class TestSaveUnconditionally:
         monkeypatch.setattr(
             callback.impl, "format_checkpoint_name", format_checkpoint_name
         )
-        trainer = MagicMock(spec=Trainer)
-        trainer.current_epoch = 2
-        trainer.global_step = 7
-        trainer.log_dir = str(tmp_path)
-        trainer.strategy.broadcast.side_effect = lambda value: value
+        mock_trainer.current_epoch = 2
+        mock_trainer.global_step = 7
+        mock_trainer.log_dir = str(tmp_path)
+        mock_trainer.strategy.broadcast.side_effect = lambda value: value
 
-        callback.save_unconditionally(trainer)
+        callback.save_unconditionally(mock_trainer)
 
         format_checkpoint_name.assert_called_once()
         expected = tmp_path / "epoch=2-step=7.ckpt"
-        trainer.strategy.broadcast.assert_called_once_with(str(expected))
-        trainer.save_checkpoint.assert_called_once_with(expected)
+        mock_trainer.strategy.broadcast.assert_called_once_with(str(expected))
+        mock_trainer.save_checkpoint.assert_called_once_with(expected)
 
     def test_prefers_explicit_dirpath(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Prefer an explicitly configured dirpath over the trainer's log_dir."""
         callback = UnconditionalCheckpoint()
@@ -63,18 +52,17 @@ class TestSaveUnconditionally:
         monkeypatch.setattr(
             callback.impl, "format_checkpoint_name", MagicMock(return_value="last.ckpt")
         )
-        trainer = MagicMock(spec=Trainer)
-        trainer.current_epoch = 0
-        trainer.global_step = 0
-        trainer.log_dir = str(tmp_path / "logs")
-        trainer.strategy.broadcast.side_effect = lambda value: value
+        mock_trainer.current_epoch = 0
+        mock_trainer.global_step = 0
+        mock_trainer.log_dir = str(tmp_path / "logs")
+        mock_trainer.strategy.broadcast.side_effect = lambda value: value
 
-        callback.save_unconditionally(trainer)
+        callback.save_unconditionally(mock_trainer)
 
-        trainer.save_checkpoint.assert_called_once_with(explicit / "last.ckpt")
+        mock_trainer.save_checkpoint.assert_called_once_with(explicit / "last.ckpt")
 
     def test_uses_absolute_checkpoint_name_as_is(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Do not prepend a directory when the checkpoint name is already absolute."""
         callback = UnconditionalCheckpoint()
@@ -84,59 +72,62 @@ class TestSaveUnconditionally:
             "format_checkpoint_name",
             MagicMock(return_value=str(absolute_checkpoint)),
         )
-        trainer = MagicMock(spec=Trainer)
-        trainer.current_epoch = 0
-        trainer.global_step = 0
-        trainer.log_dir = str(tmp_path / "logs")
-        trainer.strategy.broadcast.side_effect = lambda value: value
+        mock_trainer.current_epoch = 0
+        mock_trainer.global_step = 0
+        mock_trainer.log_dir = str(tmp_path / "logs")
+        mock_trainer.strategy.broadcast.side_effect = lambda value: value
 
-        callback.save_unconditionally(trainer)
+        callback.save_unconditionally(mock_trainer)
 
-        trainer.save_checkpoint.assert_called_once_with(absolute_checkpoint)
+        mock_trainer.save_checkpoint.assert_called_once_with(absolute_checkpoint)
 
     def test_uses_relative_name_when_no_dirpath_available(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, mock_trainer: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Fall back to the raw relative checkpoint name when no directory is available."""
         callback = UnconditionalCheckpoint()
         monkeypatch.setattr(
             callback.impl, "format_checkpoint_name", MagicMock(return_value="last.ckpt")
         )
-        trainer = MagicMock(spec=Trainer)
-        trainer.current_epoch = 0
-        trainer.global_step = 0
-        trainer.log_dir = None
-        trainer.strategy.broadcast.side_effect = lambda value: value
+        mock_trainer.current_epoch = 0
+        mock_trainer.global_step = 0
+        mock_trainer.log_dir = None
+        mock_trainer.strategy.broadcast.side_effect = lambda value: value
 
-        callback.save_unconditionally(trainer)
+        callback.save_unconditionally(mock_trainer)
 
-        trainer.save_checkpoint.assert_called_once_with(Path("last.ckpt"))
+        mock_trainer.save_checkpoint.assert_called_once_with(Path("last.ckpt"))
 
 
 class TestOnTrainEnd:
     """Tests for on_train_end."""
 
     def test_disabled_by_default_does_not_save(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Do not save a checkpoint when on_train_end is not opted in."""
         callback = UnconditionalCheckpoint(on_train_end=False)
         save = MagicMock()
         monkeypatch.setattr(callback, "save_unconditionally", save)
 
-        callback.on_train_end(MagicMock(spec=Trainer), MagicMock(spec=LightningModule))
+        callback.on_train_end(mock_trainer, mock_module)
 
         save.assert_not_called()
 
     def test_enabled_saves_unconditionally(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_trainer: MagicMock,
+        mock_module: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Save a checkpoint when on_train_end is opted in."""
         callback = UnconditionalCheckpoint(on_train_end=True)
         save = MagicMock()
         monkeypatch.setattr(callback, "save_unconditionally", save)
-        trainer = MagicMock(spec=Trainer)
 
-        callback.on_train_end(trainer, MagicMock(spec=LightningModule))
+        callback.on_train_end(mock_trainer, mock_module)
 
-        save.assert_called_once_with(trainer)
+        save.assert_called_once_with(mock_trainer)

--- a/tests/callbacks/test_unconditional_checkpoint.py
+++ b/tests/callbacks/test_unconditional_checkpoint.py
@@ -2,68 +2,141 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-import torch
-from lightning.pytorch.callbacks import WeightAveraging
+from lightning import LightningModule, Trainer
 
-from icenet_mp.callbacks.ema_weight_averaging_callback import EMAWeightAveragingCallback
 from icenet_mp.callbacks.unconditional_checkpoint import UnconditionalCheckpoint
 
 
-def test_unconditional_checkpoint_dirpath_roundtrip(tmp_path: Path) -> None:
-    callback = UnconditionalCheckpoint()
+class TestDirpath:
+    """Tests for the dirpath property."""
 
-    callback.dirpath = tmp_path
+    def test_roundtrip(self, tmp_path: Path) -> None:
+        """Store and return a truthy dirpath unchanged."""
+        callback = UnconditionalCheckpoint()
 
-    assert callback.dirpath == tmp_path
+        callback.dirpath = tmp_path
 
+        assert callback.dirpath == tmp_path
 
-def test_unconditional_checkpoint_uses_log_dir_and_broadcast(tmp_path: Path) -> None:
-    callback = UnconditionalCheckpoint()
-    callback.impl.format_checkpoint_name = MagicMock(return_value="epoch=2-step=7.ckpt")
-    trainer = MagicMock()
-    trainer.current_epoch = 2
-    trainer.global_step = 7
-    trainer.log_dir = str(tmp_path)
-    trainer.strategy.broadcast.side_effect = lambda value: value
+    def test_setter_ignores_falsy_value(self, tmp_path: Path) -> None:
+        """Leave an existing dirpath unchanged when set to a falsy value."""
+        callback = UnconditionalCheckpoint()
+        callback.dirpath = tmp_path
 
-    callback.save_unconditionally(trainer)
+        callback.dirpath = None
 
-    callback.impl.format_checkpoint_name.assert_called_once()
-    expected = tmp_path / "epoch=2-step=7.ckpt"
-    trainer.strategy.broadcast.assert_called_once_with(str(expected))
-    trainer.save_checkpoint.assert_called_once_with(expected)
+        assert callback.dirpath == tmp_path
 
 
-def test_unconditional_checkpoint_prefers_explicit_dirpath(tmp_path: Path) -> None:
-    callback = UnconditionalCheckpoint()
-    explicit = tmp_path / "checkpoints"
-    callback.dirpath = explicit
-    callback.impl.format_checkpoint_name = MagicMock(return_value="last.ckpt")
-    trainer = MagicMock()
-    trainer.current_epoch = 0
-    trainer.global_step = 0
-    trainer.log_dir = str(tmp_path / "logs")
-    trainer.strategy.broadcast.side_effect = lambda value: value
+class TestSaveUnconditionally:
+    """Tests for save_unconditionally."""
 
-    callback.save_unconditionally(trainer)
+    def test_uses_log_dir_and_broadcast(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fall back to the trainer's log_dir and broadcast the resolved path."""
+        callback = UnconditionalCheckpoint()
+        format_checkpoint_name = MagicMock(return_value="epoch=2-step=7.ckpt")
+        monkeypatch.setattr(
+            callback.impl, "format_checkpoint_name", format_checkpoint_name
+        )
+        trainer = MagicMock(spec=Trainer)
+        trainer.current_epoch = 2
+        trainer.global_step = 7
+        trainer.log_dir = str(tmp_path)
+        trainer.strategy.broadcast.side_effect = lambda value: value
 
-    trainer.save_checkpoint.assert_called_once_with(explicit / "last.ckpt")
+        callback.save_unconditionally(trainer)
+
+        format_checkpoint_name.assert_called_once()
+        expected = tmp_path / "epoch=2-step=7.ckpt"
+        trainer.strategy.broadcast.assert_called_once_with(str(expected))
+        trainer.save_checkpoint.assert_called_once_with(expected)
+
+    def test_prefers_explicit_dirpath(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Prefer an explicitly configured dirpath over the trainer's log_dir."""
+        callback = UnconditionalCheckpoint()
+        explicit = tmp_path / "checkpoints"
+        callback.dirpath = explicit
+        monkeypatch.setattr(
+            callback.impl, "format_checkpoint_name", MagicMock(return_value="last.ckpt")
+        )
+        trainer = MagicMock(spec=Trainer)
+        trainer.current_epoch = 0
+        trainer.global_step = 0
+        trainer.log_dir = str(tmp_path / "logs")
+        trainer.strategy.broadcast.side_effect = lambda value: value
+
+        callback.save_unconditionally(trainer)
+
+        trainer.save_checkpoint.assert_called_once_with(explicit / "last.ckpt")
+
+    def test_uses_absolute_checkpoint_name_as_is(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Do not prepend a directory when the checkpoint name is already absolute."""
+        callback = UnconditionalCheckpoint()
+        absolute_checkpoint = tmp_path / "absolute.ckpt"
+        monkeypatch.setattr(
+            callback.impl,
+            "format_checkpoint_name",
+            MagicMock(return_value=str(absolute_checkpoint)),
+        )
+        trainer = MagicMock(spec=Trainer)
+        trainer.current_epoch = 0
+        trainer.global_step = 0
+        trainer.log_dir = str(tmp_path / "logs")
+        trainer.strategy.broadcast.side_effect = lambda value: value
+
+        callback.save_unconditionally(trainer)
+
+        trainer.save_checkpoint.assert_called_once_with(absolute_checkpoint)
+
+    def test_uses_relative_name_when_no_dirpath_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fall back to the raw relative checkpoint name when no directory is available."""
+        callback = UnconditionalCheckpoint()
+        monkeypatch.setattr(
+            callback.impl, "format_checkpoint_name", MagicMock(return_value="last.ckpt")
+        )
+        trainer = MagicMock(spec=Trainer)
+        trainer.current_epoch = 0
+        trainer.global_step = 0
+        trainer.log_dir = None
+        trainer.strategy.broadcast.side_effect = lambda value: value
+
+        callback.save_unconditionally(trainer)
+
+        trainer.save_checkpoint.assert_called_once_with(Path("last.ckpt"))
 
 
-def test_unconditional_checkpoint_train_end_is_opt_in(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    trainer = MagicMock()
-    module = MagicMock()
+class TestOnTrainEnd:
+    """Tests for on_train_end."""
 
-    disabled = UnconditionalCheckpoint(on_train_end=False)
-    disabled_save = MagicMock()
-    monkeypatch.setattr(disabled, "save_unconditionally", disabled_save)
-    disabled.on_train_end(trainer, module)
-    disabled_save.assert_not_called()
+    def test_disabled_by_default_does_not_save(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Do not save a checkpoint when on_train_end is not opted in."""
+        callback = UnconditionalCheckpoint(on_train_end=False)
+        save = MagicMock()
+        monkeypatch.setattr(callback, "save_unconditionally", save)
 
-    enabled = UnconditionalCheckpoint(on_train_end=True)
-    enabled_save = MagicMock()
-    monkeypatch.setattr(enabled, "save_unconditionally", enabled_save)
-    enabled.on_train_end(trainer, module)
-    enabled_save.assert_called_once_with(trainer)
+        callback.on_train_end(MagicMock(spec=Trainer), MagicMock(spec=LightningModule))
+
+        save.assert_not_called()
+
+    def test_enabled_saves_unconditionally(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Save a checkpoint when on_train_end is opted in."""
+        callback = UnconditionalCheckpoint(on_train_end=True)
+        save = MagicMock()
+        monkeypatch.setattr(callback, "save_unconditionally", save)
+        trainer = MagicMock(spec=Trainer)
+
+        callback.on_train_end(trainer, MagicMock(spec=LightningModule))
+
+        save.assert_called_once_with(trainer)


### PR DESCRIPTION
## Summary

Adds focused test coverage for callback paths not covered by the existing ActivationSaver test PR:

- EMA update scheduling by step and epoch
- parameterless-model handling
- delegation to Lightning's weight-averaging hooks for parameterised modules
- unconditional checkpoint directory handling and path construction
- distributed filepath broadcast and checkpoint save calls
- opt-in checkpoint saving at training end

## Testing

- test-only change; production behaviour is unchanged
- full repository CI will run when the PR is opened

Part of #62.