### PR TITLE
Add fixed-coordinate SetConv encoder for sparse observations

### DIFF
--- a/icenet_mp/geotools/__init__.py
+++ b/icenet_mp/geotools/__init__.py
@@ -7,7 +7,7 @@ from .grid_factory import (
     epsg_6931_builder,
     epsg_6932_builder,
 )
-from .reproject import nearest_neighbour_indices
+from .reproject import nearest_neighbour_indices, pairwise_haversine_distances
 
 grid_factory = GridFactory()
 grid_factory.register_crs("EPSG:4326n", epsg_4326n_builder)
@@ -20,4 +20,5 @@ __all__ = [
     "GeographicGrid",
     "grid_factory",
     "nearest_neighbour_indices",
+    "pairwise_haversine_distances",
 ]

--- a/icenet_mp/geotools/reproject.py
+++ b/icenet_mp/geotools/reproject.py
@@ -3,11 +3,33 @@ import time
 from itertools import product
 
 import numpy as np
-from haversine import haversine_vector
+from haversine import Unit, haversine_vector
 
 from icenet_mp.types.typedefs import ArrayHWV, ArrayIndices2D
 
 logger = logging.getLogger(__name__)
+
+
+def pairwise_haversine_distances(
+    input_latlons: np.ndarray,
+    output_latlons: np.ndarray,
+    *,
+    unit: Unit = Unit.KILOMETERS,
+) -> np.ndarray:
+    """Return pairwise great-circle distances from output to input coordinates.
+
+    Both arrays must have shape ``[points, 2]`` with latitude then longitude.
+    The returned matrix has shape ``[n_output, n_input]``.
+    """
+    if input_latlons.ndim != 2 or input_latlons.shape[1] != 2:  # noqa: PLR2004
+        msg = f"Input lat/lons must have shape [points, 2], got {input_latlons.shape}"
+        raise ValueError(msg)
+    if output_latlons.ndim != 2 or output_latlons.shape[1] != 2:  # noqa: PLR2004
+        msg = f"Output lat/lons must have shape [points, 2], got {output_latlons.shape}"
+        raise ValueError(msg)
+    return np.asarray(
+        haversine_vector(input_latlons, output_latlons, unit=unit, comb=True)
+    )
 
 
 def nearest_neighbour_indices(

--- a/icenet_mp/models/encoders/__init__.py
+++ b/icenet_mp/models/encoders/__init__.py
@@ -4,6 +4,7 @@ from .deep_compression_encoder import DeepCompressionEncoder
 from .naive_linear_encoder import NaiveLinearEncoder
 from .piecewise_encoder import PiecewiseEncoder
 from .reprojection_encoder import ReprojectionEncoder
+from .setconv_encoder import SetConvEncoder
 
 __all__ = [
     "BaseEncoder",
@@ -12,4 +13,5 @@ __all__ = [
     "NaiveLinearEncoder",
     "PiecewiseEncoder",
     "ReprojectionEncoder",
+    "SetConvEncoder",
 ]

--- a/icenet_mp/models/encoders/setconv_encoder.py
+++ b/icenet_mp/models/encoders/setconv_encoder.py
@@ -1,0 +1,142 @@
+"""SetConv encoder for sparse or irregular observations on fixed coordinates."""
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+from torch import nn
+
+from icenet_mp.types import DataSpace, TensorNCHW
+
+from .base_encoder import BaseEncoder
+
+
+class SetConvEncoder(BaseEncoder):
+    """Map sparse observations at fixed coordinates onto a regular latent grid.
+
+    The encoder applies a Gaussian set convolution on the sphere. For each output
+    grid cell it computes a distance-weighted mean of all finite observations and
+    a corresponding observation-density feature, then mixes those features with a
+    learnable 1x1 convolution.
+
+    Input locations are taken from ``latitudes_fn``/``longitudes_fn`` under the
+    input dataset name. Output locations are taken from ``project_to``. This first
+    implementation intentionally assumes those sensor coordinates are fixed across
+    timesteps; moving-sensor support can be added once coordinates are carried with
+    each sample by the data pipeline.
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        data_space_in: DataSpace,
+        latent_space: tuple[int, int],
+        project_to: str,
+        output_channels: int | None = None,
+        length_scale_degrees: float = 5.0,
+        learnable_length_scale: bool = True,
+        latitudes_fn: Callable[[], dict[str, list[float]]] | None = None,
+        longitudes_fn: Callable[[], dict[str, list[float]]] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialise a fixed-coordinate SetConv encoder."""
+        if length_scale_degrees <= 0:
+            msg = "length_scale_degrees must be positive."
+            raise ValueError(msg)
+
+        super().__init__(
+            data_space_in=data_space_in,
+            latent_space=latent_space,
+            output_channels=output_channels or data_space_in.channels,
+            latitudes_fn=latitudes_fn,
+            longitudes_fn=longitudes_fn,
+            **kwargs,
+        )
+
+        self.project_from = data_space_in.name
+        self.project_to = project_to
+        self._validate_coordinates()
+
+        self.register_buffer(
+            "input_xyz",
+            self._latlon_to_xyz(
+                self.latitudes[self.project_from], self.longitudes[self.project_from]
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "output_xyz",
+            self._latlon_to_xyz(
+                self.latitudes[self.project_to], self.longitudes[self.project_to]
+            ),
+            persistent=False,
+        )
+
+        self.log_length_scale_degrees = nn.Parameter(
+            torch.tensor(length_scale_degrees).log(),
+            requires_grad=learnable_length_scale,
+        )
+        self.feature_projection = nn.Conv2d(
+            2 * data_space_in.channels,
+            self.data_space_out.channels,
+            kernel_size=1,
+        )
+
+    @staticmethod
+    def _latlon_to_xyz(latitudes: list[float], longitudes: list[float]) -> torch.Tensor:
+        """Convert latitude/longitude degrees to unit-sphere Cartesian coordinates."""
+        lat = torch.deg2rad(torch.tensor(latitudes, dtype=torch.float32))
+        lon = torch.deg2rad(torch.tensor(longitudes, dtype=torch.float32))
+        cos_lat = torch.cos(lat)
+        return torch.stack(
+            (cos_lat * torch.cos(lon), cos_lat * torch.sin(lon), torch.sin(lat)), dim=-1
+        )
+
+    def _validate_coordinates(self) -> None:
+        """Validate that source and target coordinate counts match their data spaces."""
+        for name, expected in (
+            (self.project_from, self.data_space_in.area),
+            (self.project_to, self.data_space_out.area),
+        ):
+            if name not in self.latitudes or name not in self.longitudes:
+                msg = f"Missing coordinates for dataset '{name}'."
+                raise ValueError(msg)
+            if len(self.latitudes[name]) != expected or len(self.longitudes[name]) != expected:
+                msg = (
+                    f"Dataset '{name}' has an incompatible coordinate count; "
+                    f"expected {expected} latitude/longitude pairs."
+                )
+                raise ValueError(msg)
+
+    def _kernel(self, *, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+        """Return Gaussian weights from every output point to every input point."""
+        input_xyz = self.input_xyz.to(device=device, dtype=dtype)
+        output_xyz = self.output_xyz.to(device=device, dtype=dtype)
+        squared_distance = torch.sum(
+            (output_xyz[:, None, :] - input_xyz[None, :, :]) ** 2, dim=-1
+        )
+
+        # Convert the learnable angular scale into a unit-sphere chord distance.
+        angle = torch.deg2rad(self.log_length_scale_degrees.exp()).to(dtype=dtype)
+        chord_scale = (2 * torch.sin(angle / 2)).clamp_min(torch.finfo(dtype).eps)
+        return torch.exp(-0.5 * squared_distance / chord_scale.square())
+
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Interpolate finite observations onto the latent grid and project channels."""
+        batch_size, channels, _, _ = x.shape
+        values = x.reshape(batch_size, channels, self.data_space_in.area)
+        valid = torch.isfinite(values)
+        values = torch.nan_to_num(values)
+
+        kernel = self._kernel(device=x.device, dtype=x.dtype)
+        weights = kernel[None, None, :, :] * valid[:, :, None, :].to(x.dtype)
+        density = weights.sum(dim=-1)
+        weighted_values = (weights * values[:, :, None, :]).sum(dim=-1)
+        smooth = weighted_values / density.clamp_min(torch.finfo(x.dtype).eps)
+
+        features = torch.cat((smooth, torch.log1p(density)), dim=1).reshape(
+            batch_size,
+            2 * channels,
+            *self.data_space_out.shape,
+        )
+        return self.feature_projection(features)

--- a/icenet_mp/models/encoders/setconv_encoder.py
+++ b/icenet_mp/models/encoders/setconv_encoder.py
@@ -3,9 +3,12 @@
 from collections.abc import Callable
 from typing import Any
 
+import numpy as np
 import torch
+from haversine import Unit
 from torch import nn
 
+from icenet_mp.geotools import pairwise_haversine_distances
 from icenet_mp.types import DataSpace, TensorNCHW
 
 from .base_encoder import BaseEncoder
@@ -57,20 +60,22 @@ class SetConvEncoder(BaseEncoder):
         self.project_to = project_to
         self._validate_coordinates()
 
-        self.register_buffer(
-            "input_xyz",
-            self._latlon_to_xyz(
-                self.latitudes[self.project_from], self.longitudes[self.project_from]
-            ),
-            persistent=False,
+        input_latlons = np.column_stack(
+            (
+                self.latitudes[self.project_from],
+                self.longitudes[self.project_from],
+            )
         )
-        self.register_buffer(
-            "output_xyz",
-            self._latlon_to_xyz(
-                self.latitudes[self.project_to], self.longitudes[self.project_to]
-            ),
-            persistent=False,
+        output_latlons = np.column_stack(
+            (self.latitudes[self.project_to], self.longitudes[self.project_to])
         )
+        angular_distances = torch.tensor(
+            pairwise_haversine_distances(
+                input_latlons, output_latlons, unit=Unit.RADIANS
+            ),
+            dtype=torch.float32,
+        )
+        self.register_buffer("_angular_distances", angular_distances, persistent=False)
 
         self.log_length_scale_degrees = nn.Parameter(
             torch.tensor(length_scale_degrees).log(),
@@ -82,16 +87,6 @@ class SetConvEncoder(BaseEncoder):
             kernel_size=1,
         )
 
-    @staticmethod
-    def _latlon_to_xyz(latitudes: list[float], longitudes: list[float]) -> torch.Tensor:
-        """Convert latitude/longitude degrees to unit-sphere Cartesian coordinates."""
-        lat = torch.deg2rad(torch.tensor(latitudes, dtype=torch.float32))
-        lon = torch.deg2rad(torch.tensor(longitudes, dtype=torch.float32))
-        cos_lat = torch.cos(lat)
-        return torch.stack(
-            (cos_lat * torch.cos(lon), cos_lat * torch.sin(lon), torch.sin(lat)), dim=-1
-        )
-
     def _validate_coordinates(self) -> None:
         """Validate that source and target coordinate counts match their data spaces."""
         for name, expected in (
@@ -101,7 +96,10 @@ class SetConvEncoder(BaseEncoder):
             if name not in self.latitudes or name not in self.longitudes:
                 msg = f"Missing coordinates for dataset '{name}'."
                 raise ValueError(msg)
-            if len(self.latitudes[name]) != expected or len(self.longitudes[name]) != expected:
+            if (
+                len(self.latitudes[name]) != expected
+                or len(self.longitudes[name]) != expected
+            ):
                 msg = (
                     f"Dataset '{name}' has an incompatible coordinate count; "
                     f"expected {expected} latitude/longitude pairs."
@@ -110,16 +108,14 @@ class SetConvEncoder(BaseEncoder):
 
     def _kernel(self, *, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
         """Return Gaussian weights from every output point to every input point."""
-        input_xyz = self.input_xyz.to(device=device, dtype=dtype)
-        output_xyz = self.output_xyz.to(device=device, dtype=dtype)
-        squared_distance = torch.sum(
-            (output_xyz[:, None, :] - input_xyz[None, :, :]) ** 2, dim=-1
+        angular_distances = self.get_buffer("_angular_distances").to(
+            device=device, dtype=dtype
         )
-
-        # Convert the learnable angular scale into a unit-sphere chord distance.
-        angle = torch.deg2rad(self.log_length_scale_degrees.exp()).to(dtype=dtype)
-        chord_scale = (2 * torch.sin(angle / 2)).clamp_min(torch.finfo(dtype).eps)
-        return torch.exp(-0.5 * squared_distance / chord_scale.square())
+        length_scale = torch.deg2rad(self.log_length_scale_degrees.exp()).to(
+            device=device, dtype=dtype
+        )
+        length_scale = length_scale.clamp_min(torch.finfo(dtype).eps)
+        return torch.exp(-0.5 * angular_distances.square() / length_scale.square())
 
     def forward(self, x: TensorNCHW) -> TensorNCHW:
         """Interpolate finite observations onto the latent grid and project channels."""

--- a/tests/models/test_setconv_encoder.py
+++ b/tests/models/test_setconv_encoder.py
@@ -1,0 +1,116 @@
+import pytest
+import torch
+
+from icenet_mp.models.encoders import SetConvEncoder
+from icenet_mp.types import DataSpace
+
+
+def _coords() -> tuple[dict[str, list[float]], dict[str, list[float]]]:
+    latitudes = {
+        "sensors": [80.0, 80.0, 82.0],
+        "target-grid": [80.0, 80.0, 82.0, 82.0],
+    }
+    longitudes = {
+        "sensors": [-10.0, 10.0, 0.0],
+        "target-grid": [-10.0, 10.0, -10.0, 10.0],
+    }
+    return latitudes, longitudes
+
+
+def _make_encoder(*, output_channels: int = 3) -> SetConvEncoder:
+    latitudes, longitudes = _coords()
+    return SetConvEncoder(
+        data_space_in=DataSpace(name="sensors", channels=2, shape=(1, 3)),
+        latent_space=(2, 2),
+        project_to="target-grid",
+        output_channels=output_channels,
+        length_scale_degrees=3.0,
+        latitudes_fn=lambda: latitudes,
+        longitudes_fn=lambda: longitudes,
+    )
+
+
+def test_setconv_rollout_shape_and_gradients() -> None:
+    encoder = _make_encoder(output_channels=4)
+    values = torch.randn(2, 3, 2, 1, 3, requires_grad=True)
+
+    output = encoder.rollout(values)
+
+    assert output.shape == (2, 3, 4, 2, 2)
+    output.sum().backward()
+    assert values.grad is not None
+    assert encoder.log_length_scale_degrees.grad is not None
+
+
+def test_setconv_ignores_missing_observations() -> None:
+    encoder = _make_encoder()
+    values = torch.tensor([[[[1.0, float("nan"), 3.0]], [[2.0, 4.0, float("nan")]]]])
+
+    output = encoder(values)
+
+    assert output.shape == (1, 3, 2, 2)
+    assert torch.isfinite(output).all()
+
+
+def test_setconv_recovers_values_at_matching_coordinates() -> None:
+    latitudes = {"sensors": [80.0, 80.0], "target-grid": [80.0, 80.0]}
+    longitudes = {"sensors": [-20.0, 20.0], "target-grid": [-20.0, 20.0]}
+    encoder = SetConvEncoder(
+        data_space_in=DataSpace(name="sensors", channels=1, shape=(1, 2)),
+        latent_space=(1, 2),
+        project_to="target-grid",
+        output_channels=1,
+        length_scale_degrees=0.1,
+        learnable_length_scale=False,
+        latitudes_fn=lambda: latitudes,
+        longitudes_fn=lambda: longitudes,
+    )
+    with torch.no_grad():
+        encoder.feature_projection.weight.zero_()
+        encoder.feature_projection.weight[0, 0, 0, 0] = 1.0
+        encoder.feature_projection.bias.zero_()
+
+    output = encoder(torch.tensor([[[[1.0, 3.0]]]]))
+
+    torch.testing.assert_close(output, torch.tensor([[[[1.0, 3.0]]]]), atol=1e-4, rtol=1e-4)
+
+
+def test_setconv_rejects_missing_or_mismatched_coordinates() -> None:
+    input_space = DataSpace(name="sensors", channels=1, shape=(1, 2))
+
+    with pytest.raises(ValueError, match="Missing coordinates"):
+        SetConvEncoder(
+            data_space_in=input_space,
+            latent_space=(1, 1),
+            project_to="target-grid",
+            latitudes_fn=lambda: {"sensors": [80.0, 81.0]},
+            longitudes_fn=lambda: {"sensors": [0.0, 1.0]},
+        )
+
+    with pytest.raises(ValueError, match="incompatible coordinate count"):
+        SetConvEncoder(
+            data_space_in=input_space,
+            latent_space=(1, 1),
+            project_to="target-grid",
+            latitudes_fn=lambda: {
+                "sensors": [80.0],
+                "target-grid": [80.0],
+            },
+            longitudes_fn=lambda: {
+                "sensors": [0.0],
+                "target-grid": [0.0],
+            },
+        )
+
+
+def test_setconv_rejects_non_positive_length_scale() -> None:
+    latitudes, longitudes = _coords()
+    with pytest.raises(ValueError, match="length_scale_degrees must be positive"):
+        SetConvEncoder(
+            data_space_in=DataSpace(name="sensors", channels=1, shape=(1, 3)),
+            latent_space=(2, 2),
+            project_to="target-grid",
+            length_scale_degrees=0.0,
+            latitudes_fn=lambda: latitudes,
+            longitudes_fn=lambda: longitudes,
+        )

--- a/tests/models/test_setconv_encoder.py
+++ b/tests/models/test_setconv_encoder.py
@@ -31,6 +31,7 @@ def _make_encoder(*, output_channels: int = 3) -> SetConvEncoder:
 
 
 def test_setconv_rollout_shape_and_gradients() -> None:
+    """Project a multi-step fixed-coordinate trajectory and retain gradients."""
     encoder = _make_encoder(output_channels=4)
     values = torch.randn(2, 3, 2, 1, 3, requires_grad=True)
 
@@ -43,6 +44,7 @@ def test_setconv_rollout_shape_and_gradients() -> None:
 
 
 def test_setconv_ignores_missing_observations() -> None:
+    """Ignore missing sensor values instead of propagating NaNs."""
     encoder = _make_encoder()
     values = torch.tensor([[[[1.0, float("nan"), 3.0]], [[2.0, 4.0, float("nan")]]]])
 
@@ -53,6 +55,7 @@ def test_setconv_ignores_missing_observations() -> None:
 
 
 def test_setconv_recovers_values_at_matching_coordinates() -> None:
+    """Recover observations when source and target coordinates coincide."""
     latitudes = {"sensors": [80.0, 80.0], "target-grid": [80.0, 80.0]}
     longitudes = {"sensors": [-20.0, 20.0], "target-grid": [-20.0, 20.0]}
     encoder = SetConvEncoder(
@@ -66,16 +69,21 @@ def test_setconv_recovers_values_at_matching_coordinates() -> None:
         longitudes_fn=lambda: longitudes,
     )
     with torch.no_grad():
+        assert encoder.feature_projection.weight is not None
+        assert encoder.feature_projection.bias is not None
         encoder.feature_projection.weight.zero_()
         encoder.feature_projection.weight[0, 0, 0, 0] = 1.0
         encoder.feature_projection.bias.zero_()
 
     output = encoder(torch.tensor([[[[1.0, 3.0]]]]))
 
-    torch.testing.assert_close(output, torch.tensor([[[[1.0, 3.0]]]]), atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(
+        output, torch.tensor([[[[1.0, 3.0]]]]), atol=1e-4, rtol=1e-4
+    )
 
 
 def test_setconv_rejects_missing_or_mismatched_coordinates() -> None:
+    """Reject absent coordinates or coordinate counts that do not match spaces."""
     input_space = DataSpace(name="sensors", channels=1, shape=(1, 2))
 
     with pytest.raises(ValueError, match="Missing coordinates"):
@@ -104,6 +112,7 @@ def test_setconv_rejects_missing_or_mismatched_coordinates() -> None:
 
 
 def test_setconv_rejects_non_positive_length_scale() -> None:
+    """Require a positive SetConv length scale."""
     latitudes, longitudes = _coords()
     with pytest.raises(ValueError, match="length_scale_degrees must be positive"):
         SetConvEncoder(
@@ -114,3 +123,22 @@ def test_setconv_rejects_non_positive_length_scale() -> None:
             latitudes_fn=lambda: latitudes,
             longitudes_fn=lambda: longitudes,
         )
+
+
+def test_setconv_minimal_fixed_coordinate_trajectory_example() -> None:
+    """Show the model-level shape expected from a fixed-coordinate trajectory reader."""
+    encoder = _make_encoder(output_channels=2)
+    # One sample, two forecast steps, two variables, three fixed sensor locations.
+    trajectory = torch.tensor(
+        [
+            [
+                [[[1.0, 2.0, 3.0]], [[4.0, 5.0, 6.0]]],
+                [[[2.0, 3.0, 4.0]], [[5.0, float("nan"), 7.0]]],
+            ]
+        ]
+    )
+
+    gridded = encoder.rollout(trajectory)
+
+    assert gridded.shape == (1, 2, 2, 2, 2)
+    assert torch.isfinite(gridded).all()


### PR DESCRIPTION
## Summary

- add a `SetConvEncoder` that maps sparse or irregular observations onto a regular latent grid
- use spherical Gaussian kernel weighting through the existing latitude/longitude provider interface
- include observation-density features and a configurable, optionally learnable kernel length scale
- ignore non-finite observations when aggregating sparse inputs
- export the encoder and add focused unit tests

## Scope

This first implementation assumes sensor coordinates are fixed across timesteps, matching the current pipeline coordinate interface and the limitation discussed in #40. Supporting moving sensor coordinates remains future work.

## Testing

- added rollout shape and gradient coverage
- added missing-observation coverage
- added interpolation coverage for matching source/target coordinates
- added coordinate validation and invalid-length-scale coverage
- full repository CI will run when the PR is opened

Part of #40.