### PR TITLE
Allow missing input dates to use a sentinel value

### DIFF
--- a/icenet_mp/config/base.yaml
+++ b/icenet_mp/config/base.yaml
@@ -11,3 +11,8 @@ defaults:
   - train: default
   - platform: default
   - _self_
+
+data:
+  # Set to a value such as -1.0 to keep windows with missing input dates.
+  # Forecast target dates are always required and are never filled.
+  missing_input_value: null

--- a/icenet_mp/data/combined_dataset.py
+++ b/icenet_mp/data/combined_dataset.py
@@ -16,6 +16,7 @@ class CombinedDataset(Dataset):
         target_group_name: str,
         target_variables: Sequence[str],
         *,
+        missing_input_value: float | None = None,
         n_forecast_steps: int = 1,
         n_history_steps: int = 1,
     ) -> None:
@@ -24,20 +25,23 @@ class CombinedDataset(Dataset):
         One of the datasets must be the target and all must have the same frequency. The
         number of forecast and history steps can be set, which will determine the shape
         of the NTCHW tensors returned by __getitem__.
+
+        When ``missing_input_value`` is set, missing dates inside an input dataset's
+        available time range are represented by a full tensor containing that value.
+        Forecast target dates are never filled and must always exist. ``None`` preserves
+        the existing strict intersection behaviour.
         """
         super().__init__()
 
-        # Store the number of forecast and history steps
+        self.missing_input_value = missing_input_value
         self.n_forecast_steps = n_forecast_steps
         self.n_history_steps = n_history_steps
 
-        # Create a new dataset for the target with only the selected variables
         self.target = next(
             ds for ds in datasets if ds.name == target_group_name
         ).subset(variables=target_variables)
         self.inputs = list(datasets)
 
-        # Require that all datasets have the same frequency
         frequencies = sorted({ds.frequency for ds in datasets})  # type: ignore[type-var]
         if len(frequencies) != 1:
             msg = f"Cannot combine datasets with different frequencies: {frequencies}."
@@ -46,19 +50,32 @@ class CombinedDataset(Dataset):
 
     @cached_property
     def dates(self) -> list[np.datetime64]:
-        """Get list of dates that are available in all datasets."""
-        # Identify dates that exist in all input datasets
-        input_date_set = set.intersection(*(set(ds.dates) for ds in self.inputs))
+        """Get valid forecast-window start dates."""
         target_date_set = set(self.target.dates)
+
+        if self.missing_input_value is None:
+            input_date_set = set.intersection(*(set(ds.dates) for ds in self.inputs))
+            candidate_dates = input_date_set
+            valid_history = lambda start: all(  # noqa: E731
+                date in input_date_set for date in self.get_history_steps(start)
+            )
+        else:
+            # Use the target timeline as the reference timeline. Missing history dates
+            # may be filled, but we do not fabricate dates outside any input's observed
+            # range or fabricate future target values.
+            candidate_dates = target_date_set
+
+            def valid_history(start: np.datetime64) -> bool:
+                history_dates = self.get_history_steps(start)
+                return all(
+                    all(ds.start_date <= date <= ds.end_date for date in history_dates)
+                    for ds in self.inputs
+                )
+
         available_dates = sorted(
             available_date
-            for available_date in input_date_set
-            # ... if all inputs have n_history_steps starting on start_date
-            if all(
-                date in input_date_set
-                for date in self.get_history_steps(available_date)
-            )
-            # ... and if the target has n_forecast_steps starting after the history dates
+            for available_date in candidate_dates
+            if valid_history(available_date)
             and all(
                 date in target_date_set
                 for date in self.get_forecast_steps(available_date)
@@ -88,30 +105,53 @@ class CombinedDataset(Dataset):
         return len(self.dates)
 
     def __getitem__(self, idx: int) -> dict[str, ArrayTCHW]:
-        """Return the data for a single timestep as a dictionary.
-
-        Note that because we have already checked which starting dates are valid in the
-        `dates` property, we know that the requested dates will be consecutive in each
-        data input, so we can use `get_tchw_slice` rather than `get_tchw`.
-
-        Returns:
-            A dictionary with dataset names as keys and a numpy array as the value.
-            The shape of each array is:
-            - input datasets: [n_history_steps, C_input_k, H_input_k, W_input_k]
-            - target dataset: [n_forecast_steps, C_target, H_target, W_target]
-
-        """
+        """Return one history/forecast window as a dictionary of TCHW arrays."""
         start_date = self.dates[idx]
-        return {
-            ds.name: ds.get_tchw_slice(start_date, self.n_history_steps, check=False)
-            for ds in self.inputs
-        } | {
+        history_dates = self.get_history_steps(start_date)
+
+        if self.missing_input_value is None:
+            inputs = {
+                ds.name: ds.get_tchw_slice(
+                    start_date, self.n_history_steps, check=False
+                )
+                for ds in self.inputs
+            }
+        else:
+            inputs = {
+                ds.name: self._input_window_with_missing(ds, history_dates)
+                for ds in self.inputs
+            }
+
+        return inputs | {
             "target": self.target.get_tchw_slice(
                 start_date + self.n_history_steps * self.frequency,
                 self.n_forecast_steps,
                 check=False,
             )
         }
+
+    def _input_window_with_missing(
+        self,
+        dataset: SingleDataset,
+        dates: Sequence[np.datetime64],
+    ) -> ArrayTCHW:
+        """Load input dates, replacing missing dates with the configured sentinel."""
+        if self.missing_input_value is None:
+            msg = "Missing-input filling requested without a configured sentinel value."
+            raise RuntimeError(msg)
+
+        available_dates = set(dataset.dates)
+        frames = [
+            dataset.get_tchw([date])[0]
+            if date in available_dates
+            else np.full(
+                dataset.space.chw,
+                self.missing_input_value,
+                dtype=np.float32,
+            )
+            for date in dates
+        ]
+        return np.stack(frames, axis=0)
 
     def get_forecast_steps(self, start_date: np.datetime64) -> list[np.datetime64]:
         """Return list of consecutive forecast dates for a given start date."""

--- a/icenet_mp/data/common_data_module.py
+++ b/icenet_mp/data/common_data_module.py
@@ -80,6 +80,11 @@ class CommonDataModule(LightningDataModule):
         self.n_forecast_steps = int(config["predict"].get("n_forecast_steps", 1))
         self.n_history_steps = int(config["predict"].get("n_history_steps", 1))
 
+        missing_input_value = config["data"].get("missing_input_value")
+        self.missing_input_value = (
+            None if missing_input_value is None else float(missing_input_value)
+        )
+
         # Set common arguments for the dataloader
         self._common_dataloader_kwargs = DataloaderArgs(
             batch_sampler=None,
@@ -196,6 +201,7 @@ class CommonDataModule(LightningDataModule):
                 ds.subset(date_ranges=self.predict_periods)
                 for ds in self.datasets.values()
             ],
+            missing_input_value=self.missing_input_value,
             n_forecast_steps=self.n_forecast_steps,
             n_history_steps=self.n_history_steps,
             target_group_name=self.target_group_name,
@@ -215,6 +221,7 @@ class CommonDataModule(LightningDataModule):
         """Construct test dataloader."""
         dataset = CombinedDataset(
             [ds.subset(date_ranges=self.test_periods) for ds in self.datasets.values()],
+            missing_input_value=self.missing_input_value,
             n_forecast_steps=self.n_forecast_steps,
             n_history_steps=self.n_history_steps,
             target_group_name=self.target_group_name,
@@ -237,6 +244,7 @@ class CommonDataModule(LightningDataModule):
                 ds.subset(date_ranges=self.train_periods)
                 for ds in self.datasets.values()
             ],
+            missing_input_value=self.missing_input_value,
             n_forecast_steps=self.n_forecast_steps,
             n_history_steps=self.n_history_steps,
             target_group_name=self.target_group_name,
@@ -256,6 +264,7 @@ class CommonDataModule(LightningDataModule):
         """Construct validation dataloader."""
         dataset = CombinedDataset(
             [ds.subset(date_ranges=self.val_periods) for ds in self.datasets.values()],
+            missing_input_value=self.missing_input_value,
             n_forecast_steps=self.n_forecast_steps,
             n_history_steps=self.n_history_steps,
             target_group_name=self.target_group_name,

--- a/tests/data/test_missing_input_dates.py
+++ b/tests/data/test_missing_input_dates.py
@@ -12,6 +12,7 @@ def _datasets_with_missing_input_date(
     mock_dataset: Path,
     dates_as_np: tuple[np.datetime64, ...],
 ) -> tuple[SingleDataset, SingleDataset]:
+    """Build a complete target dataset and an input dataset missing one date."""
     target = SingleDataset(name="target", input_files=[mock_dataset])
     sparse = SingleDataset(name="sparse", input_files=[mock_dataset])
     sparse.dates = [dates_as_np[0], *dates_as_np[2:]]
@@ -22,6 +23,7 @@ def test_missing_input_sentinel_keeps_otherwise_valid_window(
     mock_dataset: Path,
     dates_as_np: tuple[np.datetime64, ...],
 ) -> None:
+    """Sentinel filling should retain a window lost by strict intersection."""
     target, sparse = _datasets_with_missing_input_date(mock_dataset, dates_as_np)
 
     strict = CombinedDataset(
@@ -55,6 +57,7 @@ def test_missing_target_forecast_date_is_never_filled(
     mock_dataset: Path,
     dates_as_np: tuple[np.datetime64, ...],
 ) -> None:
+    """Forecast targets should remain mandatory even when inputs may be filled."""
     target, sparse = _datasets_with_missing_input_date(mock_dataset, dates_as_np)
     combined = CombinedDataset(
         datasets=[target, sparse],
@@ -73,6 +76,7 @@ def test_missing_target_forecast_date_is_never_filled(
 def test_missing_input_value_is_read_from_data_config(
     cfg_common_data_module: DictConfig,
 ) -> None:
+    """CommonDataModule should expose the configured input sentinel value."""
     cfg_common_data_module["data"]["missing_input_value"] = -1.0
 
     data_module = CommonDataModule(cfg_common_data_module)

--- a/tests/data/test_missing_input_dates.py
+++ b/tests/data/test_missing_input_dates.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import numpy as np
+from omegaconf import DictConfig
+
+from icenet_mp.data.combined_dataset import CombinedDataset
+from icenet_mp.data.common_data_module import CommonDataModule
+from icenet_mp.data.single_dataset import SingleDataset
+
+
+def _datasets_with_missing_input_date(
+    mock_dataset: Path,
+    dates_as_np: tuple[np.datetime64, ...],
+) -> tuple[SingleDataset, SingleDataset]:
+    target = SingleDataset(name="target", input_files=[mock_dataset])
+    sparse = SingleDataset(name="sparse", input_files=[mock_dataset])
+    sparse.dates = [dates_as_np[0], *dates_as_np[2:]]
+    return target, sparse
+
+
+def test_missing_input_sentinel_keeps_otherwise_valid_window(
+    mock_dataset: Path,
+    dates_as_np: tuple[np.datetime64, ...],
+) -> None:
+    target, sparse = _datasets_with_missing_input_date(mock_dataset, dates_as_np)
+
+    strict = CombinedDataset(
+        datasets=[target, sparse],
+        target_group_name="target",
+        target_variables=["ice_conc"],
+        n_history_steps=2,
+        n_forecast_steps=1,
+    )
+    filled = CombinedDataset(
+        datasets=[target, sparse],
+        target_group_name="target",
+        target_variables=["ice_conc"],
+        missing_input_value=-1.0,
+        n_history_steps=2,
+        n_forecast_steps=1,
+    )
+
+    assert dates_as_np[0] not in strict.dates
+    assert dates_as_np[0] in filled.dates
+
+    batch = filled[filled.dates.index(dates_as_np[0])]
+    np.testing.assert_array_equal(
+        batch["sparse"][1],
+        np.full((3, 2, 2), -1.0, dtype=np.float32),
+    )
+    assert not np.all(batch["sparse"][0] == -1.0)
+
+
+def test_missing_target_forecast_date_is_never_filled(
+    mock_dataset: Path,
+    dates_as_np: tuple[np.datetime64, ...],
+) -> None:
+    target, sparse = _datasets_with_missing_input_date(mock_dataset, dates_as_np)
+    combined = CombinedDataset(
+        datasets=[target, sparse],
+        target_group_name="target",
+        target_variables=["ice_conc"],
+        missing_input_value=-1.0,
+        n_history_steps=2,
+        n_forecast_steps=1,
+    )
+    combined.target.dates = [date for date in dates_as_np if date != dates_as_np[2]]
+
+    # d0 would forecast d2, so it must be rejected when d2 is missing from the target.
+    assert dates_as_np[0] not in combined.dates
+
+
+def test_missing_input_value_is_read_from_data_config(
+    cfg_common_data_module: DictConfig,
+) -> None:
+    cfg_common_data_module["data"]["missing_input_value"] = -1.0
+
+    data_module = CommonDataModule(cfg_common_data_module)
+
+    assert data_module.missing_input_value == -1.0


### PR DESCRIPTION
## Summary

Adds an opt-in path for keeping training and evaluation windows when an input dataset has missing dates.

When `data.missing_input_value` is set, for example to `-1.0`:
- the target dataset defines the reference timeline
- missing input history dates inside each dataset's available time range are replaced with a full sentinel tensor
- forecast target dates remain mandatory and are never fabricated
- windows outside an input dataset's observed time range are still rejected

The default is `null`, which preserves the current strict intersection behaviour.

## Testing

Adds coverage confirming:
- a window rejected by strict intersection is retained when missing-input filling is enabled
- a missing input history frame is replaced by the configured sentinel
- missing forecast target dates are still rejected
- the data-module config reads the sentinel value correctly

Full repository CI will run when the PR is opened.

Part of #366.