### PR TITLE
Add non-restarting warmup cosine scheduler

### DIFF
--- a/icenet_mp/config/train/scheduler/warmup_cosine.yaml
+++ b/icenet_mp/config/train/scheduler/warmup_cosine.yaml
@@ -1,0 +1,6 @@
+# Linear warm-up followed by cosine decay that stays at eta_min after training.
+_target_: icenet_mp.schedulers.WarmupCosineAnnealingLR
+warmup_epochs: 5
+total_epochs: ${..trainer.max_epochs}
+start_factor: 0.1
+eta_min: 1e-6

--- a/icenet_mp/schedulers.py
+++ b/icenet_mp/schedulers.py
@@ -1,0 +1,76 @@
+"""Learning-rate schedulers used by IceNet-MP."""
+
+import math
+
+from torch.optim import Optimizer
+from torch.optim.lr_scheduler import LRScheduler
+
+
+class WarmupCosineAnnealingLR(LRScheduler):
+    """Linearly warm up, then cosine-decay without restarting after the horizon."""
+
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        *,
+        total_epochs: int,
+        warmup_epochs: int = 5,
+        start_factor: float = 0.1,
+        eta_min: float = 1e-6,
+        last_epoch: int = -1,
+    ) -> None:
+        """Initialise the scheduler.
+
+        Args:
+            optimizer: Optimizer whose learning rate is scheduled.
+            total_epochs: Training horizon over which warm-up and decay are applied.
+            warmup_epochs: Number of initial epochs used for linear warm-up.
+            start_factor: Fraction of each base learning rate used at the start.
+            eta_min: Minimum learning rate after cosine decay.
+            last_epoch: Last completed epoch, following PyTorch scheduler semantics.
+
+        Raises:
+            ValueError: If the scheduler configuration is invalid.
+
+        """
+        if total_epochs <= 0:
+            msg = f"total_epochs must be positive, got {total_epochs}."
+            raise ValueError(msg)
+        if warmup_epochs < 0 or warmup_epochs >= total_epochs:
+            msg = (
+                "warmup_epochs must be non-negative and smaller than total_epochs, "
+                f"got {warmup_epochs} and {total_epochs}."
+            )
+            raise ValueError(msg)
+        if not 0.0 < start_factor <= 1.0:
+            msg = f"start_factor must be in (0, 1], got {start_factor}."
+            raise ValueError(msg)
+        if eta_min < 0.0:
+            msg = f"eta_min must be non-negative, got {eta_min}."
+            raise ValueError(msg)
+
+        self.total_epochs = total_epochs
+        self.warmup_epochs = warmup_epochs
+        self.start_factor = start_factor
+        self.eta_min = eta_min
+        super().__init__(optimizer, last_epoch=last_epoch)
+
+    def get_lr(self) -> list[float]:
+        """Return learning rates for the current scheduler epoch."""
+        epoch = max(self.last_epoch, 0)
+
+        if self.warmup_epochs > 0 and epoch < self.warmup_epochs:
+            progress = epoch / self.warmup_epochs
+            factor = self.start_factor + (1.0 - self.start_factor) * progress
+            return [base_lr * factor for base_lr in self.base_lrs]
+
+        decay_epochs = self.total_epochs - self.warmup_epochs
+        decay_progress = min(
+            max((epoch - self.warmup_epochs) / decay_epochs, 0.0),
+            1.0,
+        )
+        cosine = 0.5 * (1.0 + math.cos(math.pi * decay_progress))
+        return [
+            self.eta_min + (base_lr - self.eta_min) * cosine
+            for base_lr in self.base_lrs
+        ]

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -59,28 +59,30 @@ def test_warmup_cosine_never_restarts_after_training_horizon() -> None:
 
 
 @pytest.mark.parametrize(
-    "override",
+    ("total_epochs", "warmup_epochs", "start_factor", "eta_min"),
     [
-        {"total_epochs": 0},
-        {"warmup_epochs": -1},
-        {"warmup_epochs": 10},
-        {"start_factor": 0.0},
-        {"start_factor": 1.1},
-        {"eta_min": -1e-6},
+        (0, 2, 0.1, 0.01),
+        (10, -1, 0.1, 0.01),
+        (10, 10, 0.1, 0.01),
+        (10, 2, 0.0, 0.01),
+        (10, 2, 1.1, 0.01),
+        (10, 2, 0.1, -1e-6),
     ],
 )
 def test_warmup_cosine_rejects_invalid_configuration(
-    override: dict[str, int | float],
+    total_epochs: int,
+    warmup_epochs: int,
+    start_factor: float,
+    eta_min: float,
 ) -> None:
     parameter = torch.nn.Parameter(torch.tensor(1.0))
     optimizer = torch.optim.SGD([parameter], lr=1.0)
-    config: dict[str, int | float] = {
-        "total_epochs": 10,
-        "warmup_epochs": 2,
-        "start_factor": 0.1,
-        "eta_min": 0.01,
-    }
-    config.update(override)
 
     with pytest.raises(ValueError):
-        WarmupCosineAnnealingLR(optimizer, **config)
+        WarmupCosineAnnealingLR(
+            optimizer,
+            total_epochs=total_epochs,
+            warmup_epochs=warmup_epochs,
+            start_factor=start_factor,
+            eta_min=eta_min,
+        )

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1,0 +1,74 @@
+import pytest
+import torch
+
+from icenet_mp.schedulers import WarmupCosineAnnealingLR
+
+
+def _make_scheduler(**kwargs: int | float) -> tuple[
+    torch.optim.SGD, WarmupCosineAnnealingLR
+]:
+    parameter = torch.nn.Parameter(torch.tensor(1.0))
+    optimizer = torch.optim.SGD([parameter], lr=1.0)
+    scheduler = WarmupCosineAnnealingLR(
+        optimizer,
+        total_epochs=10,
+        warmup_epochs=2,
+        start_factor=0.1,
+        eta_min=0.01,
+        **kwargs,
+    )
+    return optimizer, scheduler
+
+
+def test_warmup_cosine_starts_low_and_warms_to_base_lr() -> None:
+    optimizer, scheduler = _make_scheduler()
+
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(0.1)
+
+    scheduler.step()
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(0.55)
+
+    scheduler.step()
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(1.0)
+
+
+def test_warmup_cosine_decays_after_warmup() -> None:
+    optimizer, scheduler = _make_scheduler()
+
+    for _ in range(6):
+        scheduler.step()
+
+    assert 0.01 < optimizer.param_groups[0]["lr"] < 1.0
+
+
+def test_warmup_cosine_never_restarts_after_training_horizon() -> None:
+    optimizer, scheduler = _make_scheduler()
+    learning_rates = []
+
+    for _ in range(20):
+        scheduler.step()
+        learning_rates.append(optimizer.param_groups[0]["lr"])
+
+    assert learning_rates[9] == pytest.approx(0.01)
+    assert learning_rates[10:] == pytest.approx([0.01] * 10)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"total_epochs": 0},
+        {"warmup_epochs": -1},
+        {"warmup_epochs": 10},
+        {"start_factor": 0.0},
+        {"start_factor": 1.1},
+        {"eta_min": -1e-6},
+    ],
+)
+def test_warmup_cosine_rejects_invalid_configuration(
+    kwargs: dict[str, int | float],
+) -> None:
+    parameter = torch.nn.Parameter(torch.tensor(1.0))
+    optimizer = torch.optim.SGD([parameter], lr=1.0)
+
+    with pytest.raises(ValueError):
+        WarmupCosineAnnealingLR(optimizer, total_epochs=10, **kwargs)

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -5,6 +5,7 @@ from icenet_mp.schedulers import WarmupCosineAnnealingLR
 
 
 def _make_scheduler() -> tuple[torch.optim.SGD, WarmupCosineAnnealingLR]:
+    """Build a small deterministic scheduler for unit tests."""
     parameter = torch.nn.Parameter(torch.tensor(1.0))
     optimizer = torch.optim.SGD([parameter], lr=1.0)
     scheduler = WarmupCosineAnnealingLR(
@@ -21,11 +22,13 @@ def _step_scheduler(
     optimizer: torch.optim.Optimizer,
     scheduler: WarmupCosineAnnealingLR,
 ) -> None:
+    """Advance the optimizer and scheduler by one epoch."""
     optimizer.step()
     scheduler.step()
 
 
 def test_warmup_cosine_starts_low_and_warms_to_base_lr() -> None:
+    """Warm-up should increase the learning rate to the configured base value."""
     optimizer, scheduler = _make_scheduler()
 
     assert optimizer.param_groups[0]["lr"] == pytest.approx(0.1)
@@ -38,6 +41,7 @@ def test_warmup_cosine_starts_low_and_warms_to_base_lr() -> None:
 
 
 def test_warmup_cosine_decays_after_warmup() -> None:
+    """Cosine decay should lower the learning rate after warm-up."""
     optimizer, scheduler = _make_scheduler()
 
     for _ in range(6):
@@ -47,6 +51,7 @@ def test_warmup_cosine_decays_after_warmup() -> None:
 
 
 def test_warmup_cosine_never_restarts_after_training_horizon() -> None:
+    """The learning rate should remain at eta_min beyond the training horizon."""
     optimizer, scheduler = _make_scheduler()
     learning_rates = []
 
@@ -59,14 +64,14 @@ def test_warmup_cosine_never_restarts_after_training_horizon() -> None:
 
 
 @pytest.mark.parametrize(
-    ("total_epochs", "warmup_epochs", "start_factor", "eta_min"),
+    ("total_epochs", "warmup_epochs", "start_factor", "eta_min", "expected"),
     [
-        (0, 2, 0.1, 0.01),
-        (10, -1, 0.1, 0.01),
-        (10, 10, 0.1, 0.01),
-        (10, 2, 0.0, 0.01),
-        (10, 2, 1.1, 0.01),
-        (10, 2, 0.1, -1e-6),
+        (0, 2, 0.1, 0.01, "total_epochs must be positive"),
+        (10, -1, 0.1, 0.01, "warmup_epochs must be non-negative"),
+        (10, 10, 0.1, 0.01, "warmup_epochs must be non-negative"),
+        (10, 2, 0.0, 0.01, "start_factor must be in"),
+        (10, 2, 1.1, 0.01, "start_factor must be in"),
+        (10, 2, 0.1, -1e-6, "eta_min must be non-negative"),
     ],
 )
 def test_warmup_cosine_rejects_invalid_configuration(
@@ -74,11 +79,13 @@ def test_warmup_cosine_rejects_invalid_configuration(
     warmup_epochs: int,
     start_factor: float,
     eta_min: float,
+    expected: str,
 ) -> None:
+    """Invalid scheduler settings should fail with an actionable error."""
     parameter = torch.nn.Parameter(torch.tensor(1.0))
     optimizer = torch.optim.SGD([parameter], lr=1.0)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=expected):
         WarmupCosineAnnealingLR(
             optimizer,
             total_epochs=total_epochs,

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -4,9 +4,7 @@ import torch
 from icenet_mp.schedulers import WarmupCosineAnnealingLR
 
 
-def _make_scheduler(**kwargs: int | float) -> tuple[
-    torch.optim.SGD, WarmupCosineAnnealingLR
-]:
+def _make_scheduler() -> tuple[torch.optim.SGD, WarmupCosineAnnealingLR]:
     parameter = torch.nn.Parameter(torch.tensor(1.0))
     optimizer = torch.optim.SGD([parameter], lr=1.0)
     scheduler = WarmupCosineAnnealingLR(
@@ -15,9 +13,16 @@ def _make_scheduler(**kwargs: int | float) -> tuple[
         warmup_epochs=2,
         start_factor=0.1,
         eta_min=0.01,
-        **kwargs,
     )
     return optimizer, scheduler
+
+
+def _step_scheduler(
+    optimizer: torch.optim.Optimizer,
+    scheduler: WarmupCosineAnnealingLR,
+) -> None:
+    optimizer.step()
+    scheduler.step()
 
 
 def test_warmup_cosine_starts_low_and_warms_to_base_lr() -> None:
@@ -25,10 +30,10 @@ def test_warmup_cosine_starts_low_and_warms_to_base_lr() -> None:
 
     assert optimizer.param_groups[0]["lr"] == pytest.approx(0.1)
 
-    scheduler.step()
+    _step_scheduler(optimizer, scheduler)
     assert optimizer.param_groups[0]["lr"] == pytest.approx(0.55)
 
-    scheduler.step()
+    _step_scheduler(optimizer, scheduler)
     assert optimizer.param_groups[0]["lr"] == pytest.approx(1.0)
 
 
@@ -36,7 +41,7 @@ def test_warmup_cosine_decays_after_warmup() -> None:
     optimizer, scheduler = _make_scheduler()
 
     for _ in range(6):
-        scheduler.step()
+        _step_scheduler(optimizer, scheduler)
 
     assert 0.01 < optimizer.param_groups[0]["lr"] < 1.0
 
@@ -46,7 +51,7 @@ def test_warmup_cosine_never_restarts_after_training_horizon() -> None:
     learning_rates = []
 
     for _ in range(20):
-        scheduler.step()
+        _step_scheduler(optimizer, scheduler)
         learning_rates.append(optimizer.param_groups[0]["lr"])
 
     assert learning_rates[9] == pytest.approx(0.01)
@@ -54,7 +59,7 @@ def test_warmup_cosine_never_restarts_after_training_horizon() -> None:
 
 
 @pytest.mark.parametrize(
-    "kwargs",
+    "override",
     [
         {"total_epochs": 0},
         {"warmup_epochs": -1},
@@ -65,10 +70,17 @@ def test_warmup_cosine_never_restarts_after_training_horizon() -> None:
     ],
 )
 def test_warmup_cosine_rejects_invalid_configuration(
-    kwargs: dict[str, int | float],
+    override: dict[str, int | float],
 ) -> None:
     parameter = torch.nn.Parameter(torch.tensor(1.0))
     optimizer = torch.optim.SGD([parameter], lr=1.0)
+    config: dict[str, int | float] = {
+        "total_epochs": 10,
+        "warmup_epochs": 2,
+        "start_factor": 0.1,
+        "eta_min": 0.01,
+    }
+    config.update(override)
 
     with pytest.raises(ValueError):
-        WarmupCosineAnnealingLR(optimizer, total_epochs=10, **kwargs)
+        WarmupCosineAnnealingLR(optimizer, **config)


### PR DESCRIPTION
## Summary

Adds an opt-in warm-up cosine learning-rate scheduler for the scheduler investigation in #406.

The scheduler:
- linearly warms the learning rate from a configurable start factor to the base learning rate
- applies cosine decay after warm-up
- clamps at `eta_min` after the configured training horizon instead of increasing again
- is available as `train/scheduler=warmup_cosine`
- leaves the existing default scheduler unchanged

## Testing

Adds focused tests for:
- linear warm-up behaviour
- cosine decay
- staying at `eta_min` after the training horizon without a cosine restart
- invalid scheduler configuration

Full repository CI will run when the PR is opened.

Part of #406.