### PR TITLE
Add pretrained embedding encoder

### DIFF
--- a/icenet_mp/models/encoders/__init__.py
+++ b/icenet_mp/models/encoders/__init__.py
@@ -3,6 +3,7 @@ from .cnn_encoder import CNNEncoder
 from .deep_compression_encoder import DeepCompressionEncoder
 from .naive_linear_encoder import NaiveLinearEncoder
 from .piecewise_encoder import PiecewiseEncoder
+from .pretrained_embedding_encoder import PretrainedEmbeddingEncoder
 from .reprojection_encoder import ReprojectionEncoder
 
 __all__ = [
@@ -11,5 +12,6 @@ __all__ = [
     "DeepCompressionEncoder",
     "NaiveLinearEncoder",
     "PiecewiseEncoder",
+    "PretrainedEmbeddingEncoder",
     "ReprojectionEncoder",
 ]

--- a/icenet_mp/models/encoders/pretrained_embedding_encoder.py
+++ b/icenet_mp/models/encoders/pretrained_embedding_encoder.py
@@ -1,0 +1,76 @@
+from typing import Any, Literal
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from icenet_mp.models.common.normalisations import normalisation_from_name
+from icenet_mp.types import DataSpace, TensorNCHW
+
+from .base_encoder import BaseEncoder
+
+
+class PretrainedEmbeddingEncoder(BaseEncoder):
+    """Adapt pre-computed gridded embeddings to the shared latent space.
+
+    This encoder deliberately avoids spatial feature extraction. If the incoming
+    embedding already has the requested spatial shape and channel count, the default
+    configuration is an exact pass-through. Otherwise it can resize the embedding map
+    and/or use a 1x1 convolution to project embedding channels into the latent space.
+
+    This is intended for externally generated environmental embeddings where the
+    expensive representation learning has already happened upstream.
+    """
+
+    _VALID_INTERPOLATION_MODES = frozenset(("nearest", "bilinear", "bicubic"))
+
+    def __init__(
+        self,
+        *,
+        data_space_in: DataSpace,
+        latent_space: tuple[int, int],
+        output_channels: int | None = None,
+        interpolation_mode: Literal["nearest", "bilinear", "bicubic"] = "bilinear",
+        norm_type: str = "none",
+        **kwargs: Any,
+    ) -> None:
+        """Initialise the pretrained-embedding adapter."""
+        output_channels = output_channels or data_space_in.channels
+        if output_channels <= 0:
+            msg = "output_channels must be greater than 0."
+            raise ValueError(msg)
+        if interpolation_mode not in self._VALID_INTERPOLATION_MODES:
+            msg = (
+                f"Unsupported interpolation_mode {interpolation_mode!r}; expected one "
+                f"of {sorted(self._VALID_INTERPOLATION_MODES)}."
+            )
+            raise ValueError(msg)
+
+        super().__init__(
+            data_space_in=data_space_in,
+            latent_space=latent_space,
+            output_channels=output_channels,
+            **kwargs,
+        )
+
+        self.interpolation_mode = interpolation_mode
+        self.projection: nn.Module = (
+            nn.Identity()
+            if data_space_in.channels == output_channels
+            else nn.Conv2d(data_space_in.channels, output_channels, kernel_size=1)
+        )
+        self.normalisation = normalisation_from_name(norm_type, output_channels)
+
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Resize/project an embedding map without adding spatial convolutions."""
+        if tuple(x.shape[-2:]) != self.data_space_out.shape:
+            kwargs: dict[str, bool] = {}
+            if self.interpolation_mode in {"bilinear", "bicubic"}:
+                kwargs["align_corners"] = False
+            x = F.interpolate(
+                x,
+                size=self.data_space_out.shape,
+                mode=self.interpolation_mode,
+                **kwargs,
+            )
+        return self.normalisation(self.projection(x))

--- a/icenet_mp/models/encoders/pretrained_embedding_encoder.py
+++ b/icenet_mp/models/encoders/pretrained_embedding_encoder.py
@@ -1,7 +1,7 @@
 from typing import Any, Literal
 
 from torch import nn
-from torch.nn import functional as F
+from torch.nn import functional
 
 from icenet_mp.models.common.normalisations import normalisation_from_name
 from icenet_mp.types import DataSpace, TensorNCHW
@@ -67,7 +67,7 @@ class PretrainedEmbeddingEncoder(BaseEncoder):
             kwargs: dict[str, bool] = {}
             if self.interpolation_mode in {"bilinear", "bicubic"}:
                 kwargs["align_corners"] = False
-            x = F.interpolate(
+            x = functional.interpolate(
                 x,
                 size=self.data_space_out.shape,
                 mode=self.interpolation_mode,

--- a/icenet_mp/models/encoders/pretrained_embedding_encoder.py
+++ b/icenet_mp/models/encoders/pretrained_embedding_encoder.py
@@ -1,6 +1,5 @@
 from typing import Any, Literal
 
-import torch
 from torch import nn
 from torch.nn import functional as F
 
@@ -35,7 +34,8 @@ class PretrainedEmbeddingEncoder(BaseEncoder):
         **kwargs: Any,
     ) -> None:
         """Initialise the pretrained-embedding adapter."""
-        output_channels = output_channels or data_space_in.channels
+        if output_channels is None:
+            output_channels = data_space_in.channels
         if output_channels <= 0:
             msg = "output_channels must be greater than 0."
             raise ValueError(msg)

--- a/tests/models/test_pretrained_embedding_encoder.py
+++ b/tests/models/test_pretrained_embedding_encoder.py
@@ -1,0 +1,74 @@
+import pytest
+import torch
+
+from icenet_mp.models.encoders import PretrainedEmbeddingEncoder
+from icenet_mp.types import DataSpace
+
+
+def _space(channels: int = 4, shape: tuple[int, int] = (8, 8)) -> DataSpace:
+    return DataSpace(name="embedding", channels=channels, shape=shape)
+
+
+def test_pretrained_embedding_encoder_is_exact_passthrough_when_aligned() -> None:
+    encoder = PretrainedEmbeddingEncoder(
+        data_space_in=_space(),
+        latent_space=(8, 8),
+    )
+    x = torch.randn(2, 4, 8, 8)
+
+    output = encoder(x)
+
+    torch.testing.assert_close(output, x)
+
+
+def test_pretrained_embedding_encoder_resizes_to_latent_shape() -> None:
+    encoder = PretrainedEmbeddingEncoder(
+        data_space_in=_space(shape=(6, 10)),
+        latent_space=(12, 20),
+    )
+    x = torch.randn(2, 4, 6, 10)
+
+    output = encoder(x)
+
+    assert output.shape == (2, 4, 12, 20)
+
+
+def test_pretrained_embedding_encoder_projects_channels_and_backpropagates() -> None:
+    encoder = PretrainedEmbeddingEncoder(
+        data_space_in=_space(channels=5),
+        latent_space=(8, 8),
+        output_channels=3,
+    )
+    x = torch.randn(2, 5, 8, 8, requires_grad=True)
+
+    output = encoder(x)
+    output.square().mean().backward()
+
+    assert output.shape == (2, 3, 8, 8)
+    assert x.grad is not None
+    projection = encoder.projection
+    assert isinstance(projection, torch.nn.Conv2d)
+    assert projection.weight.grad is not None
+    assert torch.isfinite(projection.weight.grad).all()
+
+
+def test_pretrained_embedding_encoder_rollout_preserves_time_dimension() -> None:
+    encoder = PretrainedEmbeddingEncoder(
+        data_space_in=_space(channels=2, shape=(4, 4)),
+        latent_space=(8, 8),
+        output_channels=3,
+    )
+    x = torch.randn(2, 5, 2, 4, 4)
+
+    output = encoder.rollout(x)
+
+    assert output.shape == (2, 5, 3, 8, 8)
+
+
+def test_pretrained_embedding_encoder_rejects_unknown_interpolation_mode() -> None:
+    with pytest.raises(ValueError, match="Unsupported interpolation_mode"):
+        PretrainedEmbeddingEncoder(
+            data_space_in=_space(),
+            latent_space=(8, 8),
+            interpolation_mode="area",  # type: ignore[arg-type]
+        )

--- a/tests/models/test_pretrained_embedding_encoder.py
+++ b/tests/models/test_pretrained_embedding_encoder.py
@@ -10,6 +10,7 @@ def _space(channels: int = 4, shape: tuple[int, int] = (8, 8)) -> DataSpace:
 
 
 def test_pretrained_embedding_encoder_is_exact_passthrough_when_aligned() -> None:
+    """Preserve an already aligned pretrained embedding exactly."""
     encoder = PretrainedEmbeddingEncoder(
         data_space_in=_space(),
         latent_space=(8, 8),
@@ -22,6 +23,7 @@ def test_pretrained_embedding_encoder_is_exact_passthrough_when_aligned() -> Non
 
 
 def test_pretrained_embedding_encoder_resizes_to_latent_shape() -> None:
+    """Resize embeddings to the requested shared latent geometry."""
     encoder = PretrainedEmbeddingEncoder(
         data_space_in=_space(shape=(6, 10)),
         latent_space=(12, 20),
@@ -34,6 +36,7 @@ def test_pretrained_embedding_encoder_resizes_to_latent_shape() -> None:
 
 
 def test_pretrained_embedding_encoder_projects_channels_and_backpropagates() -> None:
+    """Project embedding channels with a trainable 1x1 adaptor when requested."""
     encoder = PretrainedEmbeddingEncoder(
         data_space_in=_space(channels=5),
         latent_space=(8, 8),
@@ -53,6 +56,7 @@ def test_pretrained_embedding_encoder_projects_channels_and_backpropagates() -> 
 
 
 def test_pretrained_embedding_encoder_rollout_preserves_time_dimension() -> None:
+    """Apply the embedding adaptor independently across all history timesteps."""
     encoder = PretrainedEmbeddingEncoder(
         data_space_in=_space(channels=2, shape=(4, 4)),
         latent_space=(8, 8),
@@ -66,6 +70,7 @@ def test_pretrained_embedding_encoder_rollout_preserves_time_dimension() -> None
 
 
 def test_pretrained_embedding_encoder_rejects_unknown_interpolation_mode() -> None:
+    """Reject unsupported spatial interpolation modes during construction."""
     with pytest.raises(ValueError, match="Unsupported interpolation_mode"):
         PretrainedEmbeddingEncoder(
             data_space_in=_space(),

--- a/tests/models/test_pretrained_embedding_encoder.py
+++ b/tests/models/test_pretrained_embedding_encoder.py
@@ -69,6 +69,16 @@ def test_pretrained_embedding_encoder_rollout_preserves_time_dimension() -> None
     assert output.shape == (2, 5, 3, 8, 8)
 
 
+def test_pretrained_embedding_encoder_rejects_nonpositive_output_channels() -> None:
+    """Reject invalid output channel counts before constructing the adapter."""
+    with pytest.raises(ValueError, match="output_channels must be greater than 0"):
+        PretrainedEmbeddingEncoder(
+            data_space_in=_space(),
+            latent_space=(8, 8),
+            output_channels=0,
+        )
+
+
 def test_pretrained_embedding_encoder_rejects_unknown_interpolation_mode() -> None:
     """Reject unsupported spatial interpolation modes during construction."""
     with pytest.raises(ValueError, match="Unsupported interpolation_mode"):


### PR DESCRIPTION
## Summary

- add `PretrainedEmbeddingEncoder` for externally generated gridded environmental embeddings
- preserve embeddings exactly when spatial shape and channel count already match the shared latent space
- optionally resize embedding maps without adding learned spatial convolutions
- optionally project embedding channels with a 1x1 convolution
- support optional normalisation through the existing normalisation factory
- export the encoder and add focused passthrough, resize, projection, rollout and validation tests

## Motivation

This provides a minimal pipeline integration point for the pretrained environmental embeddings discussed in #155 without forcing them through a spatial feature extractor that may unnecessarily relearn an upstream representation.

## Testing

- exact passthrough coverage
- spatial resize coverage
- channel projection and gradient coverage
- rollout shape coverage
- invalid interpolation-mode validation
- full repository CI will run when the PR is opened

Part of #155.