### PR TITLE
Add standalone module processor adapter

### DIFF
--- a/icenet_mp/models/processors/__init__.py
+++ b/icenet_mp/models/processors/__init__.py
@@ -2,6 +2,7 @@ from .base_processor import BaseProcessor
 from .ddpm import DDPMProcessor
 from .gsta import GSTAProcessor
 from .null import NullProcessor
+from .standalone_module import StandaloneModuleProcessor
 from .unet import UNetProcessor
 from .vit import VitProcessor
 
@@ -10,6 +11,7 @@ __all__ = [
     "DDPMProcessor",
     "GSTAProcessor",
     "NullProcessor",
+    "StandaloneModuleProcessor",
     "UNetProcessor",
     "VitProcessor",
 ]

--- a/icenet_mp/models/processors/standalone_module.py
+++ b/icenet_mp/models/processors/standalone_module.py
@@ -1,0 +1,59 @@
+from typing import Any, cast
+
+import hydra
+import torch
+from omegaconf import DictConfig
+from torch import nn
+
+from icenet_mp.types import TensorNCHW
+
+from .base_processor import BaseProcessor
+
+
+class StandaloneModuleProcessor(BaseProcessor):
+    """Adapt a standalone ``nn.Module`` to the IceNet-MP processor interface.
+
+    The wrapped module receives the standard processor input for one forecast step:
+    the current history window concatenated along the channel dimension. It must return
+    one NCHW latent frame with the same channel count and spatial shape as ``data_space``.
+
+    This keeps standalone model implementations independent of IceNet-MP while allowing
+    them to use the existing autoregressive rollout, training and evaluation pipeline.
+    """
+
+    def __init__(
+        self,
+        *,
+        module: nn.Module | DictConfig,
+        **kwargs: Any,
+    ) -> None:
+        """Initialise the adapter and wrapped standalone module."""
+        super().__init__(**kwargs)
+        self.module = (
+            module if isinstance(module, nn.Module) else hydra.utils.instantiate(module)
+        )
+        if not isinstance(self.module, nn.Module):
+            msg = (
+                "StandaloneModuleProcessor module must instantiate to torch.nn.Module, "
+                f"got {type(self.module).__name__}."
+            )
+            raise TypeError(msg)
+
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Run the standalone module and validate the processor tensor contract."""
+        output = self.module(x)
+        if not isinstance(output, torch.Tensor):
+            msg = (
+                "Standalone module must return a torch.Tensor, "
+                f"got {type(output).__name__}."
+            )
+            raise TypeError(msg)
+
+        expected_shape = (x.shape[0], *self.data_space.chw)
+        if tuple(output.shape) != expected_shape:
+            msg = (
+                f"Standalone module returned shape {tuple(output.shape)}, expected "
+                f"{expected_shape}."
+            )
+            raise ValueError(msg)
+        return cast("TensorNCHW", output)

--- a/tests/models/test_standalone_module_processor.py
+++ b/tests/models/test_standalone_module_processor.py
@@ -70,6 +70,12 @@ def test_standalone_adapter_instantiates_hydra_module_config() -> None:
     assert processor(torch.randn(1, 4, 8, 8)).shape == (1, 2, 8, 8)
 
 
+def test_standalone_adapter_rejects_hydra_config_without_module() -> None:
+    """Reject Hydra configurations that do not instantiate an nn.Module."""
+    with pytest.raises(TypeError, match=r"must instantiate to torch\.nn\.Module"):
+        _processor(DictConfig({"_target_": "builtins.dict"}))
+
+
 def test_standalone_adapter_rejects_wrong_output_shape() -> None:
     """Reject standalone models that violate the processor latent shape contract."""
     processor = _processor(nn.Conv2d(4, 3, kernel_size=1))
@@ -82,5 +88,5 @@ def test_standalone_adapter_rejects_non_tensor_output() -> None:
     """Reject standalone models that do not return a tensor."""
     processor = _processor(NonTensorModule())
 
-    with pytest.raises(TypeError, match="must return a torch.Tensor"):
+    with pytest.raises(TypeError, match=r"must return a torch\.Tensor"):
         processor(torch.randn(1, 4, 8, 8))

--- a/tests/models/test_standalone_module_processor.py
+++ b/tests/models/test_standalone_module_processor.py
@@ -1,0 +1,86 @@
+import pytest
+import torch
+from omegaconf import DictConfig
+from torch import nn
+
+from icenet_mp.models.processors import StandaloneModuleProcessor
+from icenet_mp.types import DataSpace
+
+
+class NonTensorModule(nn.Module):
+    """Small invalid module used to exercise output validation."""
+
+    def forward(self, _x: torch.Tensor) -> dict[str, torch.Tensor]:
+        """Return a deliberately invalid non-tensor output."""
+        return {"prediction": torch.tensor(0.0)}
+
+
+def _processor(module: nn.Module | DictConfig) -> StandaloneModuleProcessor:
+    """Build an adapter around a two-history-step latent model."""
+    return StandaloneModuleProcessor(
+        module=module,
+        data_space=DataSpace(name="latent", channels=2, shape=(8, 8)),
+        n_forecast_steps=3,
+        n_history_steps=2,
+        target_channel_offset=0,
+    )
+
+
+def test_standalone_adapter_matches_wrapped_module_forward() -> None:
+    """Return exactly the same one-step output as the standalone module."""
+    module = nn.Conv2d(4, 2, kernel_size=1)
+    processor = _processor(module)
+    x = torch.randn(3, 4, 8, 8)
+
+    expected = module(x)
+    actual = processor(x)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_standalone_adapter_rollout_and_gradients() -> None:
+    """Use the normal autoregressive rollout and preserve module gradients."""
+    module = nn.Conv2d(4, 2, kernel_size=1)
+    processor = _processor(module)
+    history = torch.randn(3, 2, 2, 8, 8, requires_grad=True)
+
+    prediction = processor.rollout(history).prediction
+    prediction.square().mean().backward()
+
+    assert prediction.shape == (3, 3, 2, 8, 8)
+    assert history.grad is not None
+    assert module.weight.grad is not None
+    assert torch.isfinite(module.weight.grad).all()
+
+
+def test_standalone_adapter_instantiates_hydra_module_config() -> None:
+    """Accept a nested Hydra configuration for an existing standalone module."""
+    processor = _processor(
+        DictConfig(
+            {
+                "_target_": "torch.nn.Conv2d",
+                "in_channels": 4,
+                "out_channels": 2,
+                "kernel_size": 1,
+            }
+        )
+    )
+
+    assert isinstance(processor.module, nn.Conv2d)
+    assert processor(torch.randn(1, 4, 8, 8)).shape == (1, 2, 8, 8)
+
+
+def test_standalone_adapter_rejects_wrong_output_shape() -> None:
+    """Reject standalone models that violate the processor latent shape contract."""
+    processor = _processor(nn.Conv2d(4, 3, kernel_size=1))
+
+    with pytest.raises(ValueError, match="expected"):
+        processor(torch.randn(1, 4, 8, 8))
+
+
+def test_standalone_adapter_rejects_non_tensor_output() -> None:
+    """Reject standalone models that do not return a tensor."""
+    processor = _processor(NonTensorModule())
+
+    with pytest.raises(TypeError, match="must return a torch.Tensor"):
+        processor(torch.randn(1, 4, 8, 8))


### PR DESCRIPTION
## Summary

Adds a generic `StandaloneModuleProcessor` adapter so existing standalone PyTorch models can be used inside the IceNet-MP processor pipeline without being rewritten as IceNet-MP classes.

The adapter:
- accepts an existing `torch.nn.Module` or a Hydra module configuration
- passes the standard concatenated history window to the wrapped model for each forecast step
- reuses the existing `BaseProcessor` autoregressive rollout
- validates that the wrapped model returns a tensor with the exact latent-space shape expected by the pipeline
- keeps gradients flowing through the wrapped standalone model
- exports the adapter through `icenet_mp.models.processors`

## Testing

Adds focused coverage for:
- exact one-step equivalence with the wrapped standalone module
- autoregressive rollout shape
- gradient propagation into the wrapped model
- Hydra module configuration instantiation
- rejection of Hydra configurations that instantiate to non-modules
- invalid output-shape handling
- non-tensor output handling

Full repository CI will run when the PR is opened.

Part of #172.