### PR TITLE
Add SimVP-style processor for temporal forecasting

### DIFF
--- a/icenet_mp/config/model/cnn_simvp_cnn.yaml
+++ b/icenet_mp/config/model/cnn_simvp_cnn.yaml
@@ -1,0 +1,48 @@
+_target_: icenet_mp.models.EncodeProcessDecode
+
+name: cnn-simvp-cnn
+
+encoders:
+  latent_space: [144, 144]
+  era5:
+    _target_: icenet_mp.models.encoders.CNNEncoder
+    kernel_size: 5
+    n_layers: 1
+    scale_factor: 3
+  float-argo:
+    _target_: icenet_mp.models.encoders.CNNEncoder
+    kernel_size: 5
+    n_layers: 1
+    scale_factor: 3
+  sic-icenet:
+    _target_: icenet_mp.models.encoders.CNNEncoder
+    kernel_size: 5
+    n_layers: 1
+    scale_factor: 3
+  sic-osisaf:
+    _target_: icenet_mp.models.encoders.CNNEncoder
+    kernel_size: 5
+    n_layers: 1
+    scale_factor: 3
+  sic-ssmis:
+    _target_: icenet_mp.models.encoders.CNNEncoder
+    kernel_size: 5
+    n_layers: 1
+    scale_factor: 3
+
+processor:
+  _target_: icenet_mp.models.processors.SimVPProcessor
+  hidden_channels: 64
+  kernel_size: 3
+  n_mixer_blocks: 4
+
+decoder:
+  _target_: icenet_mp.models.decoders.CNNDecoder
+  kernel_size: 5
+  mask_type: active
+  n_layers: 1
+  norm_type: groupnorm
+  restrict_range: sigmoid
+  scale_factor: 3
+  skip_connection:
+    method: none

--- a/icenet_mp/models/processors/__init__.py
+++ b/icenet_mp/models/processors/__init__.py
@@ -2,6 +2,7 @@ from .base_processor import BaseProcessor
 from .ddpm import DDPMProcessor
 from .gsta import GSTAProcessor
 from .null import NullProcessor
+from .simvp import SimVPProcessor
 from .unet import UNetProcessor
 from .vit import VitProcessor
 
@@ -10,6 +11,7 @@ __all__ = [
     "DDPMProcessor",
     "GSTAProcessor",
     "NullProcessor",
+    "SimVPProcessor",
     "UNetProcessor",
     "VitProcessor",
 ]

--- a/icenet_mp/models/processors/simvp.py
+++ b/icenet_mp/models/processors/simvp.py
@@ -1,0 +1,129 @@
+from typing import Any
+
+import torch
+from torch import nn
+
+from icenet_mp.types import TensorNCHW
+
+from .base_processor import BaseProcessor
+
+
+class TemporalMixerBlock(nn.Module):
+    """Residual spatial-temporal mixing block for flattened history features."""
+
+    def __init__(self, channels: int, kernel_size: int) -> None:
+        """Initialise a depthwise spatial mixer followed by channel mixing."""
+        super().__init__()
+        self.block = nn.Sequential(
+            nn.Conv2d(
+                channels,
+                channels,
+                kernel_size=kernel_size,
+                padding="same",
+                groups=channels,
+            ),
+            nn.GroupNorm(1, channels),
+            nn.SiLU(),
+            nn.Conv2d(channels, channels, kernel_size=1),
+            nn.SiLU(),
+        )
+
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Mix features while preserving shape through a residual path."""
+        return x + self.block(x)
+
+
+class SimVPProcessor(BaseProcessor):
+    """SimVP-style processor for convolutional spatio-temporal forecasting.
+
+    Each history frame is first embedded independently in space. The encoded history
+    is then flattened along the channel axis and mixed by residual convolutional blocks
+    before being decoded to the next latent frame. The standard ``BaseProcessor``
+    rollout applies this one-step model autoregressively for multiple forecast steps.
+    """
+
+    def __init__(
+        self,
+        *,
+        hidden_channels: int = 64,
+        kernel_size: int = 3,
+        n_mixer_blocks: int = 4,
+        **kwargs: Any,
+    ) -> None:
+        """Initialise the SimVP-style processor."""
+        super().__init__(**kwargs)
+        if hidden_channels <= 0:
+            msg = "hidden_channels must be greater than 0."
+            raise ValueError(msg)
+        if kernel_size <= 0 or kernel_size % 2 == 0:
+            msg = "kernel_size must be a positive odd integer."
+            raise ValueError(msg)
+        if n_mixer_blocks <= 0:
+            msg = "n_mixer_blocks must be greater than 0."
+            raise ValueError(msg)
+
+        self.hidden_channels = hidden_channels
+        history_channels = hidden_channels * self.n_history_steps
+
+        self.spatial_encoder = nn.Sequential(
+            nn.Conv2d(
+                self.data_space.channels,
+                hidden_channels,
+                kernel_size=kernel_size,
+                padding="same",
+            ),
+            nn.GroupNorm(1, hidden_channels),
+            nn.SiLU(),
+            nn.Conv2d(
+                hidden_channels,
+                hidden_channels,
+                kernel_size=kernel_size,
+                padding="same",
+            ),
+            nn.SiLU(),
+        )
+        self.temporal_mixer = nn.Sequential(
+            *(
+                TemporalMixerBlock(history_channels, kernel_size)
+                for _ in range(n_mixer_blocks)
+            )
+        )
+        self.decoder = nn.Sequential(
+            nn.Conv2d(history_channels, hidden_channels, kernel_size=1),
+            nn.SiLU(),
+            nn.Conv2d(hidden_channels, self.data_space.channels, kernel_size=1),
+        )
+
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Predict one latent frame from a concatenated history window."""
+        batch_size, channels, height, width = x.shape
+        expected_channels = self.data_space.channels * self.n_history_steps
+        if channels != expected_channels:
+            msg = (
+                f"Expected {expected_channels} concatenated history channels, "
+                f"got {channels}."
+            )
+            raise ValueError(msg)
+
+        history = x.reshape(
+            batch_size,
+            self.n_history_steps,
+            self.data_space.channels,
+            height,
+            width,
+        )
+        encoded = self.spatial_encoder(
+            history.reshape(
+                batch_size * self.n_history_steps,
+                self.data_space.channels,
+                height,
+                width,
+            )
+        )
+        encoded = encoded.reshape(
+            batch_size,
+            self.n_history_steps * self.hidden_channels,
+            height,
+            width,
+        )
+        return self.decoder(self.temporal_mixer(encoded))

--- a/icenet_mp/models/processors/simvp.py
+++ b/icenet_mp/models/processors/simvp.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-import torch
 from torch import nn
 
 from icenet_mp.types import TensorNCHW

--- a/tests/models/test_simvp_processor.py
+++ b/tests/models/test_simvp_processor.py
@@ -39,8 +39,13 @@ def test_simvp_backpropagates_through_spatial_and_temporal_blocks() -> None:
 
     assert inputs.grad is not None
     assert processor.spatial_encoder[0].weight.grad is not None
-    first_mixer = processor.temporal_mixer[0]
-    assert first_mixer.block[0].weight.grad is not None
+    mixer_gradients = [
+        parameter.grad
+        for parameter in processor.temporal_mixer.parameters()
+        if parameter.grad is not None
+    ]
+    assert mixer_gradients
+    assert any(torch.count_nonzero(gradient) > 0 for gradient in mixer_gradients)
 
 
 def test_simvp_prediction_depends_on_history_order() -> None:

--- a/tests/models/test_simvp_processor.py
+++ b/tests/models/test_simvp_processor.py
@@ -10,13 +10,13 @@ from icenet_mp.types import DataSpace
 
 def _processor(**kwargs: int) -> SimVPProcessor:
     """Build a small SimVP processor for unit tests."""
+    config = {"hidden_channels": 8, "n_mixer_blocks": 2}
+    config.update(kwargs)
     return SimVPProcessor(
         data_space=DataSpace(name="latent", channels=3, shape=(8, 8)),
         n_forecast_steps=2,
         n_history_steps=3,
-        hidden_channels=8,
-        n_mixer_blocks=2,
-        **kwargs,
+        **config,
     )
 
 

--- a/tests/models/test_simvp_processor.py
+++ b/tests/models/test_simvp_processor.py
@@ -1,0 +1,91 @@
+from importlib.resources import files
+
+import pytest
+import torch
+import yaml
+
+from icenet_mp.models.processors import SimVPProcessor
+from icenet_mp.types import DataSpace
+
+
+def _processor(**kwargs: int) -> SimVPProcessor:
+    """Build a small SimVP processor for unit tests."""
+    return SimVPProcessor(
+        data_space=DataSpace(name="latent", channels=3, shape=(8, 8)),
+        n_forecast_steps=2,
+        n_history_steps=3,
+        hidden_channels=8,
+        n_mixer_blocks=2,
+        **kwargs,
+    )
+
+
+def test_simvp_rollout_preserves_processor_shape() -> None:
+    """Return one latent frame for every requested forecast step."""
+    processor = _processor()
+    inputs = torch.randn(2, 3, 3, 8, 8)
+
+    output = processor.rollout(inputs)
+
+    assert output.prediction.shape == (2, 2, 3, 8, 8)
+
+
+def test_simvp_backpropagates_through_spatial_and_temporal_blocks() -> None:
+    """Keep the spatial encoder and temporal mixer trainable end to end."""
+    processor = _processor()
+    inputs = torch.randn(2, 3, 3, 8, 8, requires_grad=True)
+
+    processor.rollout(inputs).prediction.square().mean().backward()
+
+    assert inputs.grad is not None
+    assert processor.spatial_encoder[0].weight.grad is not None
+    first_mixer = processor.temporal_mixer[0]
+    assert first_mixer.block[0].weight.grad is not None
+
+
+def test_simvp_prediction_depends_on_history_order() -> None:
+    """Treat the history axis as ordered temporal information."""
+    torch.manual_seed(0)
+    processor = _processor()
+    inputs = torch.randn(1, 3, 3, 8, 8)
+
+    forward = processor(inputs.reshape(1, 9, 8, 8))
+    reversed_history = inputs.flip(1).reshape(1, 9, 8, 8)
+    backward = processor(reversed_history)
+
+    assert not torch.allclose(forward, backward)
+
+
+def test_simvp_rejects_invalid_history_channel_count() -> None:
+    """Reject tensors that do not contain the configured history window."""
+    processor = _processor()
+
+    with pytest.raises(ValueError, match="Expected 9 concatenated history channels"):
+        processor(torch.randn(1, 6, 8, 8))
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"hidden_channels": 0}, "hidden_channels"),
+        ({"kernel_size": 2}, "positive odd"),
+        ({"n_mixer_blocks": 0}, "n_mixer_blocks"),
+    ],
+)
+def test_simvp_rejects_invalid_configuration(
+    kwargs: dict[str, int], message: str
+) -> None:
+    """Validate processor hyperparameters at construction time."""
+    with pytest.raises(ValueError, match=message):
+        _processor(**kwargs)
+
+
+def test_simvp_model_config_selects_processor() -> None:
+    """Expose a ready-to-run CNN/SimVP/CNN model configuration."""
+    config_path = files("icenet_mp.config") / "model" / "cnn_simvp_cnn.yaml"
+    config = yaml.safe_load(config_path.read_text())
+
+    assert config["name"] == "cnn-simvp-cnn"
+    assert config["processor"]["_target_"] == (
+        "icenet_mp.models.processors.SimVPProcessor"
+    )


### PR DESCRIPTION
## Summary

Adds an opt-in SimVP-style latent processor as another temporal forecasting architecture for #156.

The processor:
- embeds each history frame independently with a shared spatial encoder
- preserves history ordering by concatenating encoded frame features
- mixes spatio-temporal features with residual depthwise/pointwise convolution blocks
- decodes the mixed representation to the next latent frame
- uses the existing autoregressive `BaseProcessor` rollout for multi-step forecasts
- includes a ready-to-run `cnn-simvp-cnn` model configuration

Existing models and defaults are unchanged.

## Testing

Adds focused coverage for:
- multi-step rollout shape
- gradient flow through spatial and temporal components
- sensitivity to history ordering
- invalid history shapes
- hyperparameter validation
- model configuration selection

Full repository CI will run when the PR is opened.

Part of #156.