### PR TITLE
Add configurable temporal stride for weekly forecasting experiments

### DIFF
--- a/icenet_mp/data/combined_dataset.py
+++ b/icenet_mp/data/combined_dataset.py
@@ -109,10 +109,7 @@ class CombinedDataset(Dataset):
         else:
             history_dates = self.get_history_steps(start_date)
             forecast_dates = self.get_forecast_steps(start_date)
-            inputs = {
-                ds.name: ds.get_tchw(history_dates)
-                for ds in self.inputs
-            }
+            inputs = {ds.name: ds.get_tchw(history_dates) for ds in self.inputs}
             target = self.target.get_tchw(forecast_dates)
 
         return inputs | {"target": target}

--- a/icenet_mp/data/combined_dataset.py
+++ b/icenet_mp/data/combined_dataset.py
@@ -18,47 +18,50 @@ class CombinedDataset(Dataset):
         *,
         n_forecast_steps: int = 1,
         n_history_steps: int = 1,
+        step_stride: int = 1,
     ) -> None:
         """Initialise a combined dataset from a sequence of SingleDatasets.
 
         One of the datasets must be the target and all must have the same frequency. The
         number of forecast and history steps can be set, which will determine the shape
-        of the NTCHW tensors returned by __getitem__.
+        of the NTCHW tensors returned by __getitem__. ``step_stride`` controls the number
+        of native dataset timesteps between consecutive history/forecast states. For a
+        daily dataset, ``step_stride=7`` therefore produces weekly-spaced model steps.
         """
         super().__init__()
 
-        # Store the number of forecast and history steps
+        if step_stride < 1:
+            msg = f"step_stride must be at least 1, got {step_stride}."
+            raise ValueError(msg)
+
         self.n_forecast_steps = n_forecast_steps
         self.n_history_steps = n_history_steps
+        self.step_stride = step_stride
 
-        # Create a new dataset for the target with only the selected variables
         self.target = next(
             ds for ds in datasets if ds.name == target_group_name
         ).subset(variables=target_variables)
         self.inputs = list(datasets)
 
-        # Require that all datasets have the same frequency
         frequencies = sorted({ds.frequency for ds in datasets})  # type: ignore[type-var]
         if len(frequencies) != 1:
             msg = f"Cannot combine datasets with different frequencies: {frequencies}."
             raise ValueError(msg)
         self.frequency = frequencies[0]
+        self.step_frequency = self.frequency * self.step_stride
 
     @cached_property
     def dates(self) -> list[np.datetime64]:
-        """Get list of dates that are available in all datasets."""
-        # Identify dates that exist in all input datasets
+        """Get list of dates that form complete strided history/forecast windows."""
         input_date_set = set.intersection(*(set(ds.dates) for ds in self.inputs))
         target_date_set = set(self.target.dates)
         available_dates = sorted(
             available_date
             for available_date in input_date_set
-            # ... if all inputs have n_history_steps starting on start_date
             if all(
                 date in input_date_set
                 for date in self.get_history_steps(available_date)
             )
-            # ... and if the target has n_forecast_steps starting after the history dates
             and all(
                 date in target_date_set
                 for date in self.get_forecast_steps(available_date)
@@ -88,40 +91,42 @@ class CombinedDataset(Dataset):
         return len(self.dates)
 
     def __getitem__(self, idx: int) -> dict[str, ArrayTCHW]:
-        """Return the data for a single timestep as a dictionary.
-
-        Note that because we have already checked which starting dates are valid in the
-        `dates` property, we know that the requested dates will be consecutive in each
-        data input, so we can use `get_tchw_slice` rather than `get_tchw`.
-
-        Returns:
-            A dictionary with dataset names as keys and a numpy array as the value.
-            The shape of each array is:
-            - input datasets: [n_history_steps, C_input_k, H_input_k, W_input_k]
-            - target dataset: [n_forecast_steps, C_target, H_target, W_target]
-
-        """
+        """Return the strided history and forecast tensors for one start date."""
         start_date = self.dates[idx]
-        return {
-            ds.name: ds.get_tchw_slice(start_date, self.n_history_steps, check=False)
-            for ds in self.inputs
-        } | {
-            "target": self.target.get_tchw_slice(
+
+        if self.step_stride == 1:
+            inputs = {
+                ds.name: ds.get_tchw_slice(
+                    start_date, self.n_history_steps, check=False
+                )
+                for ds in self.inputs
+            }
+            target = self.target.get_tchw_slice(
                 start_date + self.n_history_steps * self.frequency,
                 self.n_forecast_steps,
                 check=False,
             )
-        }
+        else:
+            history_dates = self.get_history_steps(start_date)
+            forecast_dates = self.get_forecast_steps(start_date)
+            inputs = {
+                ds.name: ds.get_tchw(history_dates)
+                for ds in self.inputs
+            }
+            target = self.target.get_tchw(forecast_dates)
+
+        return inputs | {"target": target}
 
     def get_forecast_steps(self, start_date: np.datetime64) -> list[np.datetime64]:
-        """Return list of consecutive forecast dates for a given start date."""
+        """Return forecast dates at the configured temporal stride."""
         return [
-            start_date + (idx + self.n_history_steps) * self.frequency
+            start_date + (idx + self.n_history_steps) * self.step_frequency
             for idx in range(self.n_forecast_steps)
         ]
 
     def get_history_steps(self, start_date: np.datetime64) -> list[np.datetime64]:
-        """Return list of consecutive history dates for a given start date."""
+        """Return history dates at the configured temporal stride."""
         return [
-            start_date + idx * self.frequency for idx in range(self.n_history_steps)
+            start_date + idx * self.step_frequency
+            for idx in range(self.n_history_steps)
         ]

--- a/icenet_mp/data/common_data_module.py
+++ b/icenet_mp/data/common_data_module.py
@@ -185,9 +185,7 @@ class CommonDataModule(LightningDataModule):
         self._common_dataloader_kwargs["persistent_workers"] = n_workers > 0
         self._common_dataloader_kwargs["prefetch_factor"] = 1 if n_workers > 0 else None
 
-    def _combined_dataset(
-        self, datasets: list[SingleDataset]
-    ) -> CombinedDataset:
+    def _combined_dataset(self, datasets: list[SingleDataset]) -> CombinedDataset:
         """Construct a combined dataset with the configured temporal spacing."""
         return CombinedDataset(
             datasets,
@@ -230,10 +228,7 @@ class CommonDataModule(LightningDataModule):
     def train_dataloader(self) -> DataLoader[dict[str, ArrayTCHW]]:
         """Construct train dataloader."""
         dataset = self._combined_dataset(
-            [
-                ds.subset(date_ranges=self.train_periods)
-                for ds in self.datasets.values()
-            ]
+            [ds.subset(date_ranges=self.train_periods) for ds in self.datasets.values()]
         )
         logger.info(
             "Loaded training dataset with %d dates between %s and %s.",

--- a/icenet_mp/data/common_data_module.py
+++ b/icenet_mp/data/common_data_module.py
@@ -25,10 +25,8 @@ class CommonDataModule(LightningDataModule):
         """
         super().__init__()
 
-        # Load paths
         self.base_path = Path(config["base_path"])
 
-        # Construct dataset groups
         self.dataset_groups = defaultdict(list)
         for dataset in config["data"]["datasets"].values():
             self.dataset_groups[dataset["group_as"]].append(
@@ -42,7 +40,6 @@ class CommonDataModule(LightningDataModule):
             for path in paths:
                 logger.info("%s - %s", " " * (len(str(idx)) + 1), path)
 
-        # Check prediction target
         self.target_group_name = config["predict"]["target"]["group_name"]
         if self.target_group_name not in self.dataset_groups:
             available_groups = ", ".join(sorted(self.dataset_groups)) or "<none>"
@@ -57,7 +54,6 @@ class CommonDataModule(LightningDataModule):
             "variables", []
         )
 
-        # Set periods for train, validation, and test
         self.batch_size = int(config["data"]["split"]["batch_size"])
         self.predict_periods = [
             {str(k): None if v is None else str(v) for k, v in period.items()}
@@ -76,18 +72,20 @@ class CommonDataModule(LightningDataModule):
             for period in config["data"]["split"]["validate"]
         ]
 
-        # Set history and forecast steps
         self.n_forecast_steps = int(config["predict"].get("n_forecast_steps", 1))
         self.n_history_steps = int(config["predict"].get("n_history_steps", 1))
+        self.step_stride = int(config["predict"].get("step_stride", 1))
+        if self.step_stride < 1:
+            msg = f"predict.step_stride must be at least 1, got {self.step_stride}."
+            raise ValueError(msg)
 
-        # Set common arguments for the dataloader
         self._common_dataloader_kwargs = DataloaderArgs(
             batch_sampler=None,
             batch_size=self.batch_size,
             drop_last=False,
             num_workers=0,
             persistent_workers=False,
-            prefetch_factor=None,  # must be None when num_workers=0
+            prefetch_factor=None,
             sampler=None,
             worker_init_fn=None,
         )
@@ -187,19 +185,26 @@ class CommonDataModule(LightningDataModule):
         self._common_dataloader_kwargs["persistent_workers"] = n_workers > 0
         self._common_dataloader_kwargs["prefetch_factor"] = 1 if n_workers > 0 else None
 
-    def predict_dataloader(
-        self,
-    ) -> DataLoader[dict[str, ArrayTCHW]]:
+    def _combined_dataset(
+        self, datasets: list[SingleDataset]
+    ) -> CombinedDataset:
+        """Construct a combined dataset with the configured temporal spacing."""
+        return CombinedDataset(
+            datasets,
+            n_forecast_steps=self.n_forecast_steps,
+            n_history_steps=self.n_history_steps,
+            step_stride=self.step_stride,
+            target_group_name=self.target_group_name,
+            target_variables=self.target_variables,
+        )
+
+    def predict_dataloader(self) -> DataLoader[dict[str, ArrayTCHW]]:
         """Construct predict dataloader."""
-        dataset = CombinedDataset(
+        dataset = self._combined_dataset(
             [
                 ds.subset(date_ranges=self.predict_periods)
                 for ds in self.datasets.values()
-            ],
-            n_forecast_steps=self.n_forecast_steps,
-            n_history_steps=self.n_history_steps,
-            target_group_name=self.target_group_name,
-            target_variables=self.target_variables,
+            ]
         )
         logger.info(
             "Loaded predict dataset with %d dates between %s and %s.",
@@ -209,16 +214,10 @@ class CommonDataModule(LightningDataModule):
         )
         return DataLoader(dataset, shuffle=False, **self._common_dataloader_kwargs)
 
-    def test_dataloader(
-        self,
-    ) -> DataLoader[dict[str, ArrayTCHW]]:
+    def test_dataloader(self) -> DataLoader[dict[str, ArrayTCHW]]:
         """Construct test dataloader."""
-        dataset = CombinedDataset(
-            [ds.subset(date_ranges=self.test_periods) for ds in self.datasets.values()],
-            n_forecast_steps=self.n_forecast_steps,
-            n_history_steps=self.n_history_steps,
-            target_group_name=self.target_group_name,
-            target_variables=self.target_variables,
+        dataset = self._combined_dataset(
+            [ds.subset(date_ranges=self.test_periods) for ds in self.datasets.values()]
         )
         logger.info(
             "Loaded test dataset with %d dates between %s and %s.",
@@ -228,19 +227,13 @@ class CommonDataModule(LightningDataModule):
         )
         return DataLoader(dataset, shuffle=False, **self._common_dataloader_kwargs)
 
-    def train_dataloader(
-        self,
-    ) -> DataLoader[dict[str, ArrayTCHW]]:
+    def train_dataloader(self) -> DataLoader[dict[str, ArrayTCHW]]:
         """Construct train dataloader."""
-        dataset = CombinedDataset(
+        dataset = self._combined_dataset(
             [
                 ds.subset(date_ranges=self.train_periods)
                 for ds in self.datasets.values()
-            ],
-            n_forecast_steps=self.n_forecast_steps,
-            n_history_steps=self.n_history_steps,
-            target_group_name=self.target_group_name,
-            target_variables=self.target_variables,
+            ]
         )
         logger.info(
             "Loaded training dataset with %d dates between %s and %s.",
@@ -250,16 +243,10 @@ class CommonDataModule(LightningDataModule):
         )
         return DataLoader(dataset, shuffle=True, **self._common_dataloader_kwargs)
 
-    def val_dataloader(
-        self,
-    ) -> DataLoader[dict[str, ArrayTCHW]]:
+    def val_dataloader(self) -> DataLoader[dict[str, ArrayTCHW]]:
         """Construct validation dataloader."""
-        dataset = CombinedDataset(
-            [ds.subset(date_ranges=self.val_periods) for ds in self.datasets.values()],
-            n_forecast_steps=self.n_forecast_steps,
-            n_history_steps=self.n_history_steps,
-            target_group_name=self.target_group_name,
-            target_variables=self.target_variables,
+        dataset = self._combined_dataset(
+            [ds.subset(date_ranges=self.val_periods) for ds in self.datasets.values()]
         )
         logger.info(
             "Loaded validation dataset with %d dates between %s and %s.",

--- a/tests/data/test_temporal_step_stride.py
+++ b/tests/data/test_temporal_step_stride.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+from omegaconf import DictConfig
+
+from icenet_mp.data.combined_dataset import CombinedDataset
+from icenet_mp.data.common_data_module import CommonDataModule
+from icenet_mp.data.single_dataset import SingleDataset
+
+
+def test_weekly_stride_spaces_history_and_forecast_dates(
+    mock_dataset: Path,
+    dates_as_np: tuple[np.datetime64, ...],
+) -> None:
+    """Space model timesteps by the configured multiple of native data frequency."""
+    dataset = SingleDataset(name="dataset", input_files=[mock_dataset])
+    # Extend the fixture's daily timeline so a weekly-spaced window is available.
+    start = dates_as_np[0]
+    dataset.dates = [start + np.timedelta64(day, "D") for day in range(22)]
+
+    combined = CombinedDataset(
+        datasets=[dataset],
+        target_group_name="dataset",
+        target_variables=["ice_conc"],
+        n_history_steps=2,
+        n_forecast_steps=2,
+        step_stride=7,
+    )
+
+    assert combined.get_history_steps(start) == [
+        start,
+        start + np.timedelta64(7, "D"),
+    ]
+    assert combined.get_forecast_steps(start) == [
+        start + np.timedelta64(14, "D"),
+        start + np.timedelta64(21, "D"),
+    ]
+
+
+def test_strided_getitem_reads_exact_requested_dates(
+    mock_dataset: Path,
+    dates_as_np: tuple[np.datetime64, ...],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use date-based reads rather than contiguous slices for strided windows."""
+    dataset = SingleDataset(name="dataset", input_files=[mock_dataset])
+    start = dates_as_np[0]
+    dataset.dates = [start + np.timedelta64(day, "D") for day in range(5)]
+    combined = CombinedDataset(
+        datasets=[dataset],
+        target_group_name="dataset",
+        target_variables=["ice_conc"],
+        n_history_steps=2,
+        n_forecast_steps=1,
+        step_stride=2,
+    )
+
+    requested: list[list[np.datetime64]] = []
+    original_get_tchw = SingleDataset.get_tchw
+
+    def record_dates(
+        self: SingleDataset, dates: list[np.datetime64]
+    ) -> np.ndarray:
+        requested.append(list(dates))
+        return original_get_tchw(self, dates)
+
+    monkeypatch.setattr(SingleDataset, "get_tchw", record_dates)
+    _ = combined[0]
+
+    assert requested[0] == [start, start + np.timedelta64(2, "D")]
+    assert requested[1] == [start + np.timedelta64(4, "D")]
+
+
+def test_temporal_stride_rejects_nonpositive_values(mock_dataset: Path) -> None:
+    """Reject zero or negative temporal spacing."""
+    dataset = SingleDataset(name="dataset", input_files=[mock_dataset])
+
+    with pytest.raises(ValueError, match="step_stride must be at least 1"):
+        CombinedDataset(
+            datasets=[dataset],
+            target_group_name="dataset",
+            target_variables=["ice_conc"],
+            step_stride=0,
+        )
+
+
+def test_common_data_module_reads_predict_step_stride(
+    cfg_common_data_module: DictConfig,
+) -> None:
+    """Expose temporal spacing through the prediction configuration."""
+    cfg_common_data_module["predict"]["step_stride"] = 7
+
+    data_module = CommonDataModule(cfg_common_data_module)
+
+    assert data_module.step_stride == 7
+
+
+def test_common_data_module_defaults_to_daily_stride(
+    cfg_common_data_module: DictConfig,
+) -> None:
+    """Preserve current daily behaviour when no stride is configured."""
+    cfg_common_data_module["predict"].pop("step_stride", None)
+
+    data_module = CommonDataModule(cfg_common_data_module)
+
+    assert data_module.step_stride == 1

--- a/tests/data/test_temporal_step_stride.py
+++ b/tests/data/test_temporal_step_stride.py
@@ -59,9 +59,7 @@ def test_strided_getitem_reads_exact_requested_dates(
     requested: list[list[np.datetime64]] = []
     original_get_tchw = SingleDataset.get_tchw
 
-    def record_dates(
-        self: SingleDataset, dates: list[np.datetime64]
-    ) -> np.ndarray:
+    def record_dates(self: SingleDataset, dates: list[np.datetime64]) -> np.ndarray:
         requested.append(list(dates))
         return original_get_tchw(self, dates)
 


### PR DESCRIPTION
## Summary

Adds configurable spacing between model history/forecast timesteps so the same daily datasets can be used for weekly or other lower-frequency forecasting experiments.

Set `predict.step_stride` to a positive integer:
- `1` preserves the existing daily behaviour
- `7` spaces consecutive model states seven native timesteps apart on daily data
- `30` provides a 30-day spacing experiment

The change:
- applies the stride consistently to history and forecast dates
- validates complete strided windows before exposing a sample
- uses explicit date-based reads for non-contiguous windows
- preserves the existing fast contiguous-slice path when `step_stride=1`
- wires the option through all train/validation/test/predict dataloaders

This provides the lower-frequency training path proposed in #243 without changing existing configurations.

## Testing

Adds focused coverage for:
- weekly-spaced history/forecast dates
- exact strided date reads
- invalid stride values
- CommonDataModule configuration
- daily default behaviour

Full repository CI will run when the PR is opened.

Part of #243.