### PR TITLE
Add Fractions Skill Score evaluation metric

### DIFF
--- a/icenet_mp/metrics/__init__.py
+++ b/icenet_mp/metrics/__init__.py
@@ -1,11 +1,13 @@
 from .centroid_error import CentroidErrorPerForecastDay
 from .daily_metrics import MAEPerForecastDay, RMSEPerForecastDay
+from .fractions_skill_score import FractionsSkillScorePerForecastDay
 from .icenet_accuracy import IceNetAccuracy
 from .sie_error import SIEError
 from .sie_error_abs import SeaIceExtentErrorPerForecastDay
 
 __all__ = [
     "CentroidErrorPerForecastDay",
+    "FractionsSkillScorePerForecastDay",
     "IceNetAccuracy",
     "MAEPerForecastDay",
     "RMSEPerForecastDay",

--- a/icenet_mp/metrics/fractions_skill_score.py
+++ b/icenet_mp/metrics/fractions_skill_score.py
@@ -1,0 +1,106 @@
+"""Fractions Skill Score for thresholded sea-ice concentration forecasts."""
+
+import torch
+from torchmetrics import Metric
+
+
+class FractionsSkillScorePerForecastDay(Metric):
+    """Compute Fractions Skill Score independently for each forecast lead time.
+
+    Sea-ice concentration is thresholded to a binary ice/no-ice field, converted to
+    neighbourhood fractions with average pooling, and scored using the standard FSS
+    definition. A score of 1 is perfect and 0 indicates no neighbourhood skill.
+    """
+
+    numerator: torch.Tensor
+    denominator: torch.Tensor
+
+    def __init__(
+        self,
+        *,
+        threshold: float = 0.15,
+        window_size: int = 3,
+    ) -> None:
+        """Initialise the metric.
+
+        Args:
+            threshold: SIC threshold used to define sea ice.
+            window_size: Odd neighbourhood width in grid cells.
+        """
+        super().__init__()
+        if not 0.0 <= threshold <= 1.0:
+            msg = "threshold must be between 0 and 1."
+            raise ValueError(msg)
+        if window_size <= 0 or window_size % 2 == 0:
+            msg = "window_size must be a positive odd integer."
+            raise ValueError(msg)
+
+        self.threshold = threshold
+        self.window_size = window_size
+        self.add_state(
+            "numerator",
+            default=torch.tensor([], dtype=torch.float32),
+            dist_reduce_fx="sum",
+        )
+        self.add_state(
+            "denominator",
+            default=torch.tensor([], dtype=torch.float32),
+            dist_reduce_fx="sum",
+        )
+
+    def update(self, preds: torch.Tensor, target: torch.Tensor) -> None:  # type: ignore[override]
+        """Accumulate FSS sufficient statistics for a batch of NTCHW tensors."""
+        if preds.shape != target.shape:
+            msg = f"Expected matching prediction/target shapes, got {preds.shape} and {target.shape}."
+            raise ValueError(msg)
+        if preds.ndim != 5:  # noqa: PLR2004
+            msg = f"Expected NTCHW tensors with 5 dimensions, got {preds.ndim}."
+            raise ValueError(msg)
+
+        batch_size, n_steps, channels, height, width = preds.shape
+        reshape = (batch_size * n_steps, channels, height, width)
+        padding = self.window_size // 2
+
+        pred_binary = (preds >= self.threshold).float().reshape(reshape)
+        target_binary = (target >= self.threshold).float().reshape(reshape)
+        pred_fraction = torch.nn.functional.avg_pool2d(
+            pred_binary,
+            kernel_size=self.window_size,
+            stride=1,
+            padding=padding,
+        ).reshape(batch_size, n_steps, channels, height, width)
+        target_fraction = torch.nn.functional.avg_pool2d(
+            target_binary,
+            kernel_size=self.window_size,
+            stride=1,
+            padding=padding,
+        ).reshape(batch_size, n_steps, channels, height, width)
+
+        reduce_dims = (0, 2, 3, 4)
+        numerator = ((pred_fraction - target_fraction) ** 2).sum(dim=reduce_dims)
+        denominator = (pred_fraction.square() + target_fraction.square()).sum(
+            dim=reduce_dims
+        )
+
+        if self.numerator.numel() == 0:
+            self.numerator = numerator
+            self.denominator = denominator
+        elif self.numerator.shape != numerator.shape:
+            msg = (
+                f"Time dimension mismatch: expected {self.numerator.shape[0]}, "
+                f"got {numerator.shape[0]}."
+            )
+            raise ValueError(msg)
+        else:
+            self.numerator += numerator
+            self.denominator += denominator
+
+    def compute(self) -> torch.Tensor:
+        """Return FSS for each forecast lead time."""
+        if self.numerator.numel() == 0:
+            return torch.tensor([], dtype=torch.float32, device=self.numerator.device)
+        return torch.where(
+            self.denominator > 0,
+            1.0 - self.numerator / self.denominator,
+            torch.ones_like(self.denominator),
+        )

--- a/icenet_mp/models/base_model.py
+++ b/icenet_mp/models/base_model.py
@@ -19,6 +19,7 @@ from torchmetrics import Metric, MetricCollection
 
 from icenet_mp.metrics import (
     CentroidErrorPerForecastDay,
+    FractionsSkillScorePerForecastDay,
     IceNetAccuracy,
     MAEPerForecastDay,
     RMSEPerForecastDay,
@@ -65,8 +66,9 @@ class BaseModel(LightningModule, ABC):
 
         The ``metrics`` parameter controls which metrics are computed during training,
         validation, and testing. Defaults to ``["accuracy", "mae", "rmse", "sieerror"]``;
-        pass ``"centroid_error"`` to add the value-weighted centre-of-mass distance
-        metric (only meaningful for synthetic checks where the field is a single blob).
+        pass ``"fss"`` to add Fractions Skill Score or ``"centroid_error"`` to add the
+        value-weighted centre-of-mass distance metric (only meaningful for synthetic
+        checks where the field is a single blob).
         """
         super().__init__()
 
@@ -102,6 +104,7 @@ class BaseModel(LightningModule, ABC):
             "mae": MAEPerForecastDay,
             "rmse": RMSEPerForecastDay,
             "sieerror": SeaIceExtentErrorPerForecastDay,
+            "fss": FractionsSkillScorePerForecastDay,
             "centroid_error": CentroidErrorPerForecastDay,
         }
         metric_names = (

--- a/tests/metrics/test_fractions_skill_score.py
+++ b/tests/metrics/test_fractions_skill_score.py
@@ -1,0 +1,82 @@
+import pytest
+import torch
+
+from icenet_mp.metrics import FractionsSkillScorePerForecastDay
+
+
+def _single_pixel_field(column: int) -> torch.Tensor:
+    field = torch.zeros(1, 1, 1, 5, 5)
+    field[..., 2, column] = 1.0
+    return field
+
+
+def test_fss_is_one_for_perfect_forecast() -> None:
+    """Return perfect skill for identical sea-ice fields."""
+    metric = FractionsSkillScorePerForecastDay(window_size=3)
+    target = torch.rand(2, 3, 1, 8, 8)
+
+    metric.update(target, target)
+
+    torch.testing.assert_close(metric.compute(), torch.ones(3))
+
+
+def test_fss_is_one_when_both_fields_have_no_event() -> None:
+    """Treat correctly predicted no-ice fields as perfect agreement."""
+    metric = FractionsSkillScorePerForecastDay(window_size=3)
+    zeros = torch.zeros(1, 2, 1, 6, 6)
+
+    metric.update(zeros, zeros)
+
+    torch.testing.assert_close(metric.compute(), torch.ones(2))
+
+
+def test_larger_neighbourhood_rewards_nearby_displacement() -> None:
+    """Give partial spatial credit when forecast and target ice are nearby."""
+    prediction = _single_pixel_field(2)
+    target = _single_pixel_field(3)
+
+    exact = FractionsSkillScorePerForecastDay(window_size=1)
+    neighbourhood = FractionsSkillScorePerForecastDay(window_size=3)
+    exact.update(prediction, target)
+    neighbourhood.update(prediction, target)
+
+    assert exact.compute().item() == pytest.approx(0.0)
+    assert 0.0 < neighbourhood.compute().item() < 1.0
+
+
+def test_fss_accumulates_multiple_batches_per_forecast_day() -> None:
+    """Accumulate numerator and denominator across batches before scoring."""
+    metric = FractionsSkillScorePerForecastDay(window_size=1)
+    metric.update(_single_pixel_field(2), _single_pixel_field(2))
+    metric.update(_single_pixel_field(2), _single_pixel_field(3))
+
+    assert metric.compute().shape == (1,)
+    assert metric.compute().item() == pytest.approx(0.5)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"threshold": -0.1}, "threshold"),
+        ({"threshold": 1.1}, "threshold"),
+        ({"window_size": 0}, "positive odd"),
+        ({"window_size": 2}, "positive odd"),
+    ],
+)
+def test_fss_rejects_invalid_configuration(
+    kwargs: dict[str, float | int], message: str
+) -> None:
+    """Validate threshold and neighbourhood width at construction time."""
+    with pytest.raises(ValueError, match=message):
+        FractionsSkillScorePerForecastDay(**kwargs)
+
+
+def test_fss_rejects_incompatible_tensor_shapes() -> None:
+    """Reject inputs that do not follow the shared NTCHW metric contract."""
+    metric = FractionsSkillScorePerForecastDay()
+
+    with pytest.raises(ValueError, match="matching prediction/target"):
+        metric.update(torch.zeros(1, 1, 1, 4, 4), torch.zeros(1, 2, 1, 4, 4))
+
+    with pytest.raises(ValueError, match="5 dimensions"):
+        metric.update(torch.zeros(1, 1, 4, 4), torch.zeros(1, 1, 4, 4))


### PR DESCRIPTION
## Summary

- add `FractionsSkillScorePerForecastDay` as an opt-in evaluation metric
- threshold SIC at the standard 15% ice/no-ice boundary by default
- convert binary fields to configurable neighbourhood fractions
- accumulate the standard FSS numerator and denominator across batches
- report one score per forecast lead time
- treat correctly predicted no-event fields as perfect agreement
- expose the metric as `fss` through the existing model metric registry

## Testing

- perfect forecasts
- correctly predicted no-event fields
- exact-grid displacement with a 1-cell neighbourhood
- partial spatial credit from a larger neighbourhood
- multi-batch accumulation
- invalid threshold/window configuration
- incompatible input shapes

Full repository CI will run when the PR is opened.

Part of #125.