### PR TITLE
Add GeographicGrid and GridFactory test coverage

### DIFF
--- a/tests/geotools/conftest.py
+++ b/tests/geotools/conftest.py
@@ -1,0 +1,12 @@
+import numpy as np
+import pytest
+
+from icenet_mp.geotools.geographic_grid import GeographicGrid
+
+
+@pytest.fixture
+def minimal_grid() -> GeographicGrid:
+    """A minimal 2x2 GeographicGrid for tests that need a stand-in geography."""
+    return GeographicGrid(
+        "EPSG:4326", "1.0", np.array([-0.5, 0.5]), np.array([88.5, 89.5])
+    )

--- a/tests/geotools/test_field.py
+++ b/tests/geotools/test_field.py
@@ -1,0 +1,116 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+from earthkit.data import Field
+
+from icenet_mp.geotools.geographic_field import GeographicField
+from icenet_mp.geotools.geographic_metadata import GeographicMetadata
+from icenet_mp.geotools.grid_factory import epsg_4326n_builder
+
+
+class TestGeographicField:
+    """Unit tests for the GeographicField class."""
+
+    def test_init_wraps_field_metadata_in_geographic_metadata(self) -> None:
+        """Construction eagerly wraps the underlying field's metadata with the geography."""
+        mock_field = MagicMock(spec=Field)
+        geography = epsg_4326n_builder("1p0", (2, 2))
+
+        field = GeographicField(mock_field, geography)
+
+        mock_field.metadata.assert_called_once()
+        assert isinstance(field.geo_metadata, GeographicMetadata)
+        assert field.geo_metadata.geography is geography
+        assert field._metadata is field.geo_metadata
+
+    def test_repr_includes_wrapped_field(self) -> None:
+        """__repr__ reports the wrapped field's own repr."""
+        mock_field = MagicMock(spec=Field)
+        field = GeographicField(mock_field, epsg_4326n_builder("1p0", (2, 2)))
+
+        assert repr(field) == f"GeographicField({mock_field!r})"
+
+    def test_values_delegates_to_wrapped_field(self) -> None:
+        """_values() forwards the dtype argument to the wrapped field."""
+        mock_field = MagicMock(spec=Field)
+        mock_field._values.return_value = np.array([1.0, 2.0])
+        field = GeographicField(mock_field, epsg_4326n_builder("1p0", (2, 2)))
+
+        result = field._values(dtype=np.float32)
+
+        mock_field._values.assert_called_once_with(np.float32)
+        np.testing.assert_array_equal(result, [1.0, 2.0])
+
+    def test_message_delegates_to_wrapped_field(self) -> None:
+        """message() forwards to the wrapped field."""
+        mock_field = MagicMock(spec=Field)
+        mock_field.message.return_value = b"grib-bytes"
+        field = GeographicField(mock_field, epsg_4326n_builder("1p0", (2, 2)))
+
+        assert field.message() == b"grib-bytes"
+
+    def test_to_numpy_delegates_to_wrapped_field(self) -> None:
+        """to_numpy() forwards flatten/dtype/index to the wrapped field."""
+        mock_field = MagicMock(spec=Field)
+        mock_field.to_numpy.return_value = np.array([[1.0, 2.0], [3.0, 4.0]])
+        field = GeographicField(mock_field, epsg_4326n_builder("1p0", (2, 2)))
+
+        result = field.to_numpy(flatten=True, dtype=np.float32, index=1)
+
+        mock_field.to_numpy.assert_called_once_with(
+            flatten=True, dtype=np.float32, index=1
+        )
+        np.testing.assert_array_equal(result, [[1.0, 2.0], [3.0, 4.0]])
+
+    def test_clone_wraps_cloned_field_with_same_geography(self) -> None:
+        """clone() clones the wrapped field and rewraps it with the original geography."""
+        mock_field = MagicMock(spec=Field)
+        cloned_inner_field = MagicMock(spec=Field)
+        mock_field.clone.return_value = cloned_inner_field
+        geography = epsg_4326n_builder("1p0", (2, 2))
+        field = GeographicField(mock_field, geography)
+
+        new_values = np.array([5.0, 6.0])
+        clone = field.clone(values=new_values)
+
+        mock_field.clone.assert_called_once_with(values=new_values, metadata=None)
+        assert isinstance(clone, GeographicField)
+        assert clone._field is cloned_inner_field
+        assert clone.geo_metadata.geography is geography
+
+    def test_to_latlon_returns_flattened_geography_coordinates_by_default(
+        self,
+    ) -> None:
+        """to_latlon() defaults to flattened lat/lon arrays taken from the geography."""
+        mock_field = MagicMock(spec=Field)
+        geography = epsg_4326n_builder("1p0", (2, 2))
+        field = GeographicField(mock_field, geography)
+
+        result = field.to_latlon()
+
+        np.testing.assert_allclose(result["lat"], geography.latitudes().flatten())
+        np.testing.assert_allclose(result["lon"], geography.longitudes().flatten())
+        assert result["lat"].ndim == 1
+
+    def test_to_latlon_can_keep_grid_shape_and_convert_dtype(self) -> None:
+        """to_latlon(flatten=False, dtype=...) preserves grid shape and casts dtype."""
+        mock_field = MagicMock(spec=Field)
+        geography = epsg_4326n_builder("1p0", (2, 2))
+        field = GeographicField(mock_field, geography)
+
+        result = field.to_latlon(flatten=False, dtype=np.float32)
+
+        assert result["lat"].shape == geography.shape()
+        assert result["lat"].dtype == np.float32
+        assert result["lon"].dtype == np.float32
+
+    def test_to_latlon_can_select_a_single_index(self) -> None:
+        """to_latlon(index=...) selects a single element from the flattened arrays."""
+        mock_field = MagicMock(spec=Field)
+        geography = epsg_4326n_builder("1p0", (2, 2))
+        field = GeographicField(mock_field, geography)
+
+        result = field.to_latlon(index=0)
+
+        assert result["lat"] == geography.latitudes().flatten()[0]
+        assert result["lon"] == geography.longitudes().flatten()[0]

--- a/tests/geotools/test_field.py
+++ b/tests/geotools/test_field.py
@@ -4,56 +4,63 @@ import numpy as np
 from earthkit.data import Field
 
 from icenet_mp.geotools.geographic_field import GeographicField
+from icenet_mp.geotools.geographic_grid import GeographicGrid
 from icenet_mp.geotools.geographic_metadata import GeographicMetadata
-from icenet_mp.geotools.grid_factory import epsg_4326n_builder
 
 
 class TestGeographicField:
     """Unit tests for the GeographicField class."""
 
-    def test_init_wraps_field_metadata_in_geographic_metadata(self) -> None:
+    def test_init_wraps_field_metadata_in_geographic_metadata(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """Construction eagerly wraps the underlying field's metadata with the geography."""
         mock_field = MagicMock(spec=Field)
-        geography = epsg_4326n_builder("1p0", (2, 2))
 
-        field = GeographicField(mock_field, geography)
+        field = GeographicField(mock_field, minimal_grid)
 
         mock_field.metadata.assert_called_once()
         assert isinstance(field.geo_metadata, GeographicMetadata)
-        assert field.geo_metadata.geography is geography
+        assert field.geo_metadata.geography is minimal_grid
         assert field._metadata is field.geo_metadata
 
-    def test_repr_includes_wrapped_field(self) -> None:
+    def test_repr_includes_wrapped_field(self, minimal_grid: GeographicGrid) -> None:
         """__repr__ reports the wrapped field's own repr."""
         mock_field = MagicMock(spec=Field)
-        field = GeographicField(mock_field, epsg_4326n_builder("1p0", (2, 2)))
+        field = GeographicField(mock_field, minimal_grid)
 
         assert repr(field) == f"GeographicField({mock_field!r})"
 
-    def test_values_delegates_to_wrapped_field(self) -> None:
+    def test_values_delegates_to_wrapped_field(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """_values() forwards the dtype argument to the wrapped field."""
         mock_field = MagicMock(spec=Field)
         mock_field._values.return_value = np.array([1.0, 2.0])
-        field = GeographicField(mock_field, epsg_4326n_builder("1p0", (2, 2)))
+        field = GeographicField(mock_field, minimal_grid)
 
         result = field._values(dtype=np.float32)
 
         mock_field._values.assert_called_once_with(np.float32)
         np.testing.assert_array_equal(result, [1.0, 2.0])
 
-    def test_message_delegates_to_wrapped_field(self) -> None:
+    def test_message_delegates_to_wrapped_field(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """message() forwards to the wrapped field."""
         mock_field = MagicMock(spec=Field)
         mock_field.message.return_value = b"grib-bytes"
-        field = GeographicField(mock_field, epsg_4326n_builder("1p0", (2, 2)))
+        field = GeographicField(mock_field, minimal_grid)
 
         assert field.message() == b"grib-bytes"
 
-    def test_to_numpy_delegates_to_wrapped_field(self) -> None:
+    def test_to_numpy_delegates_to_wrapped_field(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """to_numpy() forwards flatten/dtype/index to the wrapped field."""
         mock_field = MagicMock(spec=Field)
         mock_field.to_numpy.return_value = np.array([[1.0, 2.0], [3.0, 4.0]])
-        field = GeographicField(mock_field, epsg_4326n_builder("1p0", (2, 2)))
+        field = GeographicField(mock_field, minimal_grid)
 
         result = field.to_numpy(flatten=True, dtype=np.float32, index=1)
 
@@ -62,13 +69,14 @@ class TestGeographicField:
         )
         np.testing.assert_array_equal(result, [[1.0, 2.0], [3.0, 4.0]])
 
-    def test_clone_wraps_cloned_field_with_same_geography(self) -> None:
+    def test_clone_wraps_cloned_field_with_same_geography(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """clone() clones the wrapped field and rewraps it with the original geography."""
         mock_field = MagicMock(spec=Field)
         cloned_inner_field = MagicMock(spec=Field)
         mock_field.clone.return_value = cloned_inner_field
-        geography = epsg_4326n_builder("1p0", (2, 2))
-        field = GeographicField(mock_field, geography)
+        field = GeographicField(mock_field, minimal_grid)
 
         new_values = np.array([5.0, 6.0])
         clone = field.clone(values=new_values)
@@ -76,41 +84,42 @@ class TestGeographicField:
         mock_field.clone.assert_called_once_with(values=new_values, metadata=None)
         assert isinstance(clone, GeographicField)
         assert clone._field is cloned_inner_field
-        assert clone.geo_metadata.geography is geography
+        assert clone.geo_metadata.geography is minimal_grid
 
     def test_to_latlon_returns_flattened_geography_coordinates_by_default(
-        self,
+        self, minimal_grid: GeographicGrid
     ) -> None:
         """to_latlon() defaults to flattened lat/lon arrays taken from the geography."""
         mock_field = MagicMock(spec=Field)
-        geography = epsg_4326n_builder("1p0", (2, 2))
-        field = GeographicField(mock_field, geography)
+        field = GeographicField(mock_field, minimal_grid)
 
         result = field.to_latlon()
 
-        np.testing.assert_allclose(result["lat"], geography.latitudes().flatten())
-        np.testing.assert_allclose(result["lon"], geography.longitudes().flatten())
+        np.testing.assert_allclose(result["lat"], minimal_grid.latitudes().flatten())
+        np.testing.assert_allclose(result["lon"], minimal_grid.longitudes().flatten())
         assert result["lat"].ndim == 1
 
-    def test_to_latlon_can_keep_grid_shape_and_convert_dtype(self) -> None:
+    def test_to_latlon_can_keep_grid_shape_and_convert_dtype(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """to_latlon(flatten=False, dtype=...) preserves grid shape and casts dtype."""
         mock_field = MagicMock(spec=Field)
-        geography = epsg_4326n_builder("1p0", (2, 2))
-        field = GeographicField(mock_field, geography)
+        field = GeographicField(mock_field, minimal_grid)
 
         result = field.to_latlon(flatten=False, dtype=np.float32)
 
-        assert result["lat"].shape == geography.shape()
+        assert result["lat"].shape == minimal_grid.shape()
         assert result["lat"].dtype == np.float32
         assert result["lon"].dtype == np.float32
 
-    def test_to_latlon_can_select_a_single_index(self) -> None:
+    def test_to_latlon_can_select_a_single_index(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """to_latlon(index=...) selects a single element from the flattened arrays."""
         mock_field = MagicMock(spec=Field)
-        geography = epsg_4326n_builder("1p0", (2, 2))
-        field = GeographicField(mock_field, geography)
+        field = GeographicField(mock_field, minimal_grid)
 
         result = field.to_latlon(index=0)
 
-        assert result["lat"] == geography.latitudes().flatten()[0]
-        assert result["lon"] == geography.longitudes().flatten()[0]
+        assert result["lat"] == minimal_grid.latitudes().flatten()[0]
+        assert result["lon"] == minimal_grid.longitudes().flatten()[0]

--- a/tests/geotools/test_geographic_grid.py
+++ b/tests/geotools/test_geographic_grid.py
@@ -12,25 +12,28 @@ from icenet_mp.geotools.grid_factory import ease2_grid_helper
 class TestGeographicGrid:
     """Unit tests for the GeographicGrid class."""
 
-    def test_coordinate_accessors_support_dtype_conversion(self) -> None:
+    def test_resolution_and_shape_return_constructor_values(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
+        """resolution() and shape() report the values derived at construction."""
+        assert minimal_grid.resolution() == "1.0"
+        assert minimal_grid.shape() == (2, 2)
+
+    def test_coordinate_accessors_support_dtype_conversion(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """Allow callers to request coordinate arrays in a different dtype."""
-        grid = GeographicGrid(
-            "EPSG:4326", "1.0", np.array([-0.5, 0.5]), np.array([-0.5, 0.5])
-        )
+        assert minimal_grid.x(dtype=np.float32).dtype == np.float32
+        assert minimal_grid.y(dtype=np.float32).dtype == np.float32
+        assert minimal_grid.latitudes(dtype=np.float32).dtype == np.float32
+        assert minimal_grid.longitudes(dtype=np.float32).dtype == np.float32
 
-        assert grid.x(dtype=np.float32).dtype == np.float32
-        assert grid.y(dtype=np.float32).dtype == np.float32
-        assert grid.latitudes(dtype=np.float32).dtype == np.float32
-        assert grid.longitudes(dtype=np.float32).dtype == np.float32
-
-    def test_latitudes_and_longitudes_pass_through_for_epsg_4326(self) -> None:
+    def test_latitudes_and_longitudes_pass_through_for_epsg_4326(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """A native EPSG:4326 grid returns its x/y arrays as lon/lat without transforming."""
-        lon_points = np.array([-1.5, -0.5, 0.5, 1.5])
-        lat_points = np.array([86.5, 87.5, 88.5, 89.5])
-        grid = GeographicGrid("EPSG:4326", "1.0", lon_points, lat_points)
-
-        np.testing.assert_allclose(grid.longitudes(), grid.x())
-        np.testing.assert_allclose(grid.latitudes(), grid.y())
+        np.testing.assert_allclose(minimal_grid.longitudes(), minimal_grid.x())
+        np.testing.assert_allclose(minimal_grid.latitudes(), minimal_grid.y())
 
     def test_latitudes_and_longitudes_transform_and_cache_for_projected_crs(
         self, monkeypatch: pytest.MonkeyPatch
@@ -54,55 +57,32 @@ class TestGeographicGrid:
         # One call above to build `expected_*`, one for the grid under test.
         assert from_crs_spy.call_count == 2
 
-    def test_mars_area(self) -> None:
+    def test_mars_area(self, minimal_grid: GeographicGrid) -> None:
         """mars_area() reports the (north, west, south, east) bounds of the grid."""
-        grid = GeographicGrid(
-            "EPSG:4326",
-            "1.0",
-            np.array([-1.5, -0.5, 0.5, 1.5]),
-            np.array([86.5, 87.5, 88.5, 89.5]),
-        )
+        assert minimal_grid.mars_area() == (89.5, -0.5, 88.5, 0.5)
 
-        assert grid.mars_area() == (89.5, -1.5, 86.5, 1.5)
-
-    def test_mars_grid(self) -> None:
+    def test_mars_grid(self, minimal_grid: GeographicGrid) -> None:
         """mars_grid() reports the per-step lat/lon spacing implied by the grid extent."""
-        grid = GeographicGrid(
-            "EPSG:4326",
-            "1.0",
-            np.array([-1.5, -0.5, 0.5, 1.5]),
-            np.array([86.5, 87.5, 88.5, 89.5]),
-        )
+        lat_step, lon_step = minimal_grid.mars_grid()
 
-        lat_step, lon_step = grid.mars_grid()
+        assert lat_step == pytest.approx(0.5)
+        assert lon_step == pytest.approx(0.5)
 
-        assert lat_step == pytest.approx(3.0 / 4)
-        assert lon_step == pytest.approx(3.0 / 4)
-
-    def test_bounding_box_matches_mars_area(self) -> None:
+    def test_bounding_box_matches_mars_area(self, minimal_grid: GeographicGrid) -> None:
         """bounding_box() wraps mars_area() in an earthkit BoundingBox."""
-        grid = GeographicGrid(
-            "EPSG:4326",
-            "1.0",
-            np.array([-1.5, -0.5, 0.5, 1.5]),
-            np.array([86.5, 87.5, 88.5, 89.5]),
-        )
+        box = minimal_grid.bounding_box()
 
-        box = grid.bounding_box()
+        assert box == BoundingBox(north=89.5, west=-0.5, south=88.5, east=0.5)
 
-        assert box == BoundingBox(north=89.5, west=-1.5, south=86.5, east=1.5)
-
-    def test_unimplemented_earthkit_grid_methods_raise(self) -> None:
+    def test_unimplemented_earthkit_grid_methods_raise(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """Keep unsupported EarthKit geography methods explicit rather than silent."""
-        grid = GeographicGrid(
-            "EPSG:4326", "1.0", np.array([-0.5, 0.5]), np.array([-0.5, 0.5])
-        )
-
         for method in (
-            grid._unique_grid_id,
-            grid.gridspec,
-            grid.grid_spec,
-            grid.projection,
+            minimal_grid._unique_grid_id,
+            minimal_grid.gridspec,
+            minimal_grid.grid_spec,
+            minimal_grid.projection,
         ):
             with pytest.raises(NotImplementedError):
                 method()

--- a/tests/geotools/test_geographic_grid.py
+++ b/tests/geotools/test_geographic_grid.py
@@ -1,75 +1,102 @@
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
+from earthkit.data.utils.bbox import BoundingBox
+from pyproj import Transformer
 
-from icenet_mp.geotools.grid_factory import (
-    ease2_grid_helper,
-    epsg_4326n_builder,
-    epsg_4326s_builder,
-    epsg_6931_builder,
-    epsg_6932_builder,
-)
+from icenet_mp.geotools.geographic_grid import GeographicGrid
+from icenet_mp.geotools.grid_factory import ease2_grid_helper
 
 
 class TestGeographicGrid:
-    """Unit tests for the GeographicGrid class and its coordinate accessors."""
+    """Unit tests for the GeographicGrid class."""
 
-    def test_ease2_grid_helper_normalises_resolution_and_centres_grid(self) -> None:
-        """Convert kilometre resolution to centred projected-coordinate arrays."""
-        resolution, h_points, w_points = ease2_grid_helper("25p0km", 4, 4)
-
-        assert resolution == "25p0km"
-        np.testing.assert_allclose(h_points, [-37500.0, -12500.0, 12500.0, 37500.0])
-        np.testing.assert_allclose(w_points, [37500.0, 12500.0, -12500.0, -37500.0])
-
-    def test_ease2_grid_helper_accepts_metres_and_rejects_bad_format(self) -> None:
-        """Normalise metre input and reject resolutions without an explicit unit."""
-        resolution, _, _ = ease2_grid_helper("25000m", 3, 3)
-        assert resolution == "25p0km"
-
-        with pytest.raises(ValueError, match="Invalid resolution format"):
-            ease2_grid_helper("25000", 3, 3)
-
-    def test_wgs84_north_builder_exposes_expected_coordinates(self) -> None:
-        """Build a northern regular lat/lon grid without coordinate transformation."""
-        grid = epsg_4326n_builder("1p0", (4, 4))
-
-        assert grid.shape() == (4, 4)
-        np.testing.assert_allclose(grid.x()[0], [-1.5, -0.5, 0.5, 1.5])
-        np.testing.assert_allclose(grid.y()[:, 0], [86.5, 87.5, 88.5, 89.5])
-        np.testing.assert_allclose(grid.longitudes(), grid.x())
-        np.testing.assert_allclose(grid.latitudes(), grid.y())
-        assert grid.mars_area() == (89.5, -1.5, 86.5, 1.5)
-
-    def test_wgs84_south_builder_exposes_expected_coordinates(self) -> None:
-        """Build a southern regular lat/lon grid with the requested shape."""
-        grid = epsg_4326s_builder("1p0", (4, 4))
-
-        np.testing.assert_allclose(grid.y()[:, 0], [-3.5, -2.5, -1.5, -0.5])
-        assert grid.mars_area() == (-0.5, -1.5, -3.5, 1.5)
-
-    def test_grid_coordinate_accessors_support_dtype_conversion(self) -> None:
+    def test_coordinate_accessors_support_dtype_conversion(self) -> None:
         """Allow callers to request coordinate arrays in a different dtype."""
-        grid = epsg_4326n_builder("1p0", (2, 2))
+        grid = GeographicGrid(
+            "EPSG:4326", "1.0", np.array([-0.5, 0.5]), np.array([-0.5, 0.5])
+        )
 
         assert grid.x(dtype=np.float32).dtype == np.float32
         assert grid.y(dtype=np.float32).dtype == np.float32
         assert grid.latitudes(dtype=np.float32).dtype == np.float32
         assert grid.longitudes(dtype=np.float32).dtype == np.float32
 
-    def test_polar_builders_set_expected_crs_and_orientation(self) -> None:
-        """Construct north/south EASE2 grids with matching projected coordinates."""
-        north = epsg_6931_builder("25p0km", (3, 5))
-        south = epsg_6932_builder("25p0km", (3, 5))
+    def test_latitudes_and_longitudes_pass_through_for_epsg_4326(self) -> None:
+        """A native EPSG:4326 grid returns its x/y arrays as lon/lat without transforming."""
+        lon_points = np.array([-1.5, -0.5, 0.5, 1.5])
+        lat_points = np.array([86.5, 87.5, 88.5, 89.5])
+        grid = GeographicGrid("EPSG:4326", "1.0", lon_points, lat_points)
 
-        assert north.native_crs == "EPSG:6931"
-        assert south.native_crs == "EPSG:6932"
-        assert north.shape() == south.shape() == (5, 3)
-        np.testing.assert_allclose(north.x(), south.x())
-        np.testing.assert_allclose(north.y(), south.y())
+        np.testing.assert_allclose(grid.longitudes(), grid.x())
+        np.testing.assert_allclose(grid.latitudes(), grid.y())
+
+    def test_latitudes_and_longitudes_transform_and_cache_for_projected_crs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A projected grid transforms x/y to lat/lon once and caches the result."""
+        from_crs_spy = MagicMock(wraps=Transformer.from_crs)
+        monkeypatch.setattr(Transformer, "from_crs", from_crs_spy)
+
+        _, h_points, w_points = ease2_grid_helper("500p0km", 2, 2)
+        grid = GeographicGrid("EPSG:6931", "500p0km", h_points, w_points)
+
+        expected_lat, expected_lon = Transformer.from_crs(
+            "EPSG:6931", "EPSG:4326"
+        ).transform(grid.x(), grid.y())
+
+        np.testing.assert_allclose(grid.latitudes(), expected_lat)
+        np.testing.assert_allclose(grid.longitudes(), expected_lon)
+        grid.latitudes()
+        grid.longitudes()
+
+        # One call above to build `expected_*`, one for the grid under test.
+        assert from_crs_spy.call_count == 2
+
+    def test_mars_area(self) -> None:
+        """mars_area() reports the (north, west, south, east) bounds of the grid."""
+        grid = GeographicGrid(
+            "EPSG:4326",
+            "1.0",
+            np.array([-1.5, -0.5, 0.5, 1.5]),
+            np.array([86.5, 87.5, 88.5, 89.5]),
+        )
+
+        assert grid.mars_area() == (89.5, -1.5, 86.5, 1.5)
+
+    def test_mars_grid(self) -> None:
+        """mars_grid() reports the per-step lat/lon spacing implied by the grid extent."""
+        grid = GeographicGrid(
+            "EPSG:4326",
+            "1.0",
+            np.array([-1.5, -0.5, 0.5, 1.5]),
+            np.array([86.5, 87.5, 88.5, 89.5]),
+        )
+
+        lat_step, lon_step = grid.mars_grid()
+
+        assert lat_step == pytest.approx(3.0 / 4)
+        assert lon_step == pytest.approx(3.0 / 4)
+
+    def test_bounding_box_matches_mars_area(self) -> None:
+        """bounding_box() wraps mars_area() in an earthkit BoundingBox."""
+        grid = GeographicGrid(
+            "EPSG:4326",
+            "1.0",
+            np.array([-1.5, -0.5, 0.5, 1.5]),
+            np.array([86.5, 87.5, 88.5, 89.5]),
+        )
+
+        box = grid.bounding_box()
+
+        assert box == BoundingBox(north=89.5, west=-1.5, south=86.5, east=1.5)
 
     def test_unimplemented_earthkit_grid_methods_raise(self) -> None:
         """Keep unsupported EarthKit geography methods explicit rather than silent."""
-        grid = epsg_4326n_builder("1p0", (2, 2))
+        grid = GeographicGrid(
+            "EPSG:4326", "1.0", np.array([-0.5, 0.5]), np.array([-0.5, 0.5])
+        )
 
         for method in (
             grid._unique_grid_id,

--- a/tests/geotools/test_geographic_grid.py
+++ b/tests/geotools/test_geographic_grid.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from icenet_mp.geotools import GeographicGrid, GridFactory
 from icenet_mp.geotools.grid_factory import (
     ease2_grid_helper,
     epsg_4326n_builder,
@@ -9,25 +8,6 @@ from icenet_mp.geotools.grid_factory import (
     epsg_6931_builder,
     epsg_6932_builder,
 )
-
-
-def test_grid_factory_registers_and_dispatches_builder() -> None:
-    """Create a grid through the builder registered for a CRS."""
-    factory = GridFactory()
-    factory.register_crs("EPSG:6931", epsg_6931_builder)
-
-    grid = factory.create("EPSG:6931", resolution="25p0km", shape=(4, 6))
-
-    assert isinstance(grid, GeographicGrid)
-    assert grid.native_crs == "EPSG:6931"
-    assert grid.resolution() == "25p0km"
-    assert grid.shape() == (6, 4)
-
-
-def test_grid_factory_rejects_unknown_crs() -> None:
-    """Reject requests for CRS builders that have not been registered."""
-    with pytest.raises(ValueError, match="No builder registered for CRS: EPSG:9999"):
-        GridFactory().create("EPSG:9999", resolution="25p0km", shape=(4, 4))
 
 
 def test_ease2_grid_helper_normalises_resolution_and_centres_grid() -> None:

--- a/tests/geotools/test_geographic_grid.py
+++ b/tests/geotools/test_geographic_grid.py
@@ -10,75 +10,72 @@ from icenet_mp.geotools.grid_factory import (
 )
 
 
-def test_ease2_grid_helper_normalises_resolution_and_centres_grid() -> None:
-    """Convert kilometre resolution to centred projected-coordinate arrays."""
-    resolution, h_points, w_points = ease2_grid_helper("25p0km", 4, 4)
+class TestGeographicGrid:
+    """Unit tests for the GeographicGrid class and its coordinate accessors."""
 
-    assert resolution == "25p0km"
-    np.testing.assert_allclose(h_points, [-37500.0, -12500.0, 12500.0, 37500.0])
-    np.testing.assert_allclose(w_points, [37500.0, 12500.0, -12500.0, -37500.0])
+    def test_ease2_grid_helper_normalises_resolution_and_centres_grid(self) -> None:
+        """Convert kilometre resolution to centred projected-coordinate arrays."""
+        resolution, h_points, w_points = ease2_grid_helper("25p0km", 4, 4)
 
+        assert resolution == "25p0km"
+        np.testing.assert_allclose(h_points, [-37500.0, -12500.0, 12500.0, 37500.0])
+        np.testing.assert_allclose(w_points, [37500.0, 12500.0, -12500.0, -37500.0])
 
-def test_ease2_grid_helper_accepts_metres_and_rejects_bad_format() -> None:
-    """Normalise metre input and reject resolutions without an explicit unit."""
-    resolution, _, _ = ease2_grid_helper("25000m", 3, 3)
-    assert resolution == "25p0km"
+    def test_ease2_grid_helper_accepts_metres_and_rejects_bad_format(self) -> None:
+        """Normalise metre input and reject resolutions without an explicit unit."""
+        resolution, _, _ = ease2_grid_helper("25000m", 3, 3)
+        assert resolution == "25p0km"
 
-    with pytest.raises(ValueError, match="Invalid resolution format"):
-        ease2_grid_helper("25000", 3, 3)
+        with pytest.raises(ValueError, match="Invalid resolution format"):
+            ease2_grid_helper("25000", 3, 3)
 
+    def test_wgs84_north_builder_exposes_expected_coordinates(self) -> None:
+        """Build a northern regular lat/lon grid without coordinate transformation."""
+        grid = epsg_4326n_builder("1p0", (4, 4))
 
-def test_wgs84_north_builder_exposes_expected_coordinates() -> None:
-    """Build a northern regular lat/lon grid without coordinate transformation."""
-    grid = epsg_4326n_builder("1p0", (4, 4))
+        assert grid.shape() == (4, 4)
+        np.testing.assert_allclose(grid.x()[0], [-1.5, -0.5, 0.5, 1.5])
+        np.testing.assert_allclose(grid.y()[:, 0], [86.5, 87.5, 88.5, 89.5])
+        np.testing.assert_allclose(grid.longitudes(), grid.x())
+        np.testing.assert_allclose(grid.latitudes(), grid.y())
+        assert grid.mars_area() == (89.5, -1.5, 86.5, 1.5)
 
-    assert grid.shape() == (4, 4)
-    np.testing.assert_allclose(grid.x()[0], [-1.5, -0.5, 0.5, 1.5])
-    np.testing.assert_allclose(grid.y()[:, 0], [86.5, 87.5, 88.5, 89.5])
-    np.testing.assert_allclose(grid.longitudes(), grid.x())
-    np.testing.assert_allclose(grid.latitudes(), grid.y())
-    assert grid.mars_area() == (89.5, -1.5, 86.5, 1.5)
+    def test_wgs84_south_builder_exposes_expected_coordinates(self) -> None:
+        """Build a southern regular lat/lon grid with the requested shape."""
+        grid = epsg_4326s_builder("1p0", (4, 4))
 
+        np.testing.assert_allclose(grid.y()[:, 0], [-3.5, -2.5, -1.5, -0.5])
+        assert grid.mars_area() == (-0.5, -1.5, -3.5, 1.5)
 
-def test_wgs84_south_builder_exposes_expected_coordinates() -> None:
-    """Build a southern regular lat/lon grid with the requested shape."""
-    grid = epsg_4326s_builder("1p0", (4, 4))
+    def test_grid_coordinate_accessors_support_dtype_conversion(self) -> None:
+        """Allow callers to request coordinate arrays in a different dtype."""
+        grid = epsg_4326n_builder("1p0", (2, 2))
 
-    np.testing.assert_allclose(grid.y()[:, 0], [-3.5, -2.5, -1.5, -0.5])
-    assert grid.mars_area() == (-0.5, -1.5, -3.5, 1.5)
+        assert grid.x(dtype=np.float32).dtype == np.float32
+        assert grid.y(dtype=np.float32).dtype == np.float32
+        assert grid.latitudes(dtype=np.float32).dtype == np.float32
+        assert grid.longitudes(dtype=np.float32).dtype == np.float32
 
+    def test_polar_builders_set_expected_crs_and_orientation(self) -> None:
+        """Construct north/south EASE2 grids with matching projected coordinates."""
+        north = epsg_6931_builder("25p0km", (3, 5))
+        south = epsg_6932_builder("25p0km", (3, 5))
 
-def test_grid_coordinate_accessors_support_dtype_conversion() -> None:
-    """Allow callers to request coordinate arrays in a different dtype."""
-    grid = epsg_4326n_builder("1p0", (2, 2))
+        assert north.native_crs == "EPSG:6931"
+        assert south.native_crs == "EPSG:6932"
+        assert north.shape() == south.shape() == (5, 3)
+        np.testing.assert_allclose(north.x(), south.x())
+        np.testing.assert_allclose(north.y(), south.y())
 
-    assert grid.x(dtype=np.float32).dtype == np.float32
-    assert grid.y(dtype=np.float32).dtype == np.float32
-    assert grid.latitudes(dtype=np.float32).dtype == np.float32
-    assert grid.longitudes(dtype=np.float32).dtype == np.float32
+    def test_unimplemented_earthkit_grid_methods_raise(self) -> None:
+        """Keep unsupported EarthKit geography methods explicit rather than silent."""
+        grid = epsg_4326n_builder("1p0", (2, 2))
 
-
-def test_polar_builders_set_expected_crs_and_orientation() -> None:
-    """Construct north/south EASE2 grids with matching projected coordinates."""
-    north = epsg_6931_builder("25p0km", (3, 5))
-    south = epsg_6932_builder("25p0km", (3, 5))
-
-    assert north.native_crs == "EPSG:6931"
-    assert south.native_crs == "EPSG:6932"
-    assert north.shape() == south.shape() == (5, 3)
-    np.testing.assert_allclose(north.x(), south.x())
-    np.testing.assert_allclose(north.y(), south.y())
-
-
-def test_unimplemented_earthkit_grid_methods_raise() -> None:
-    """Keep unsupported EarthKit geography methods explicit rather than silent."""
-    grid = epsg_4326n_builder("1p0", (2, 2))
-
-    for method in (
-        grid._unique_grid_id,
-        grid.gridspec,
-        grid.grid_spec,
-        grid.projection,
-    ):
-        with pytest.raises(NotImplementedError):
-            method()
+        for method in (
+            grid._unique_grid_id,
+            grid.gridspec,
+            grid.grid_spec,
+            grid.projection,
+        ):
+            with pytest.raises(NotImplementedError):
+                method()

--- a/tests/geotools/test_grid.py
+++ b/tests/geotools/test_grid.py
@@ -1,0 +1,99 @@
+import numpy as np
+import pytest
+
+from icenet_mp.geotools import GeographicGrid, GridFactory
+from icenet_mp.geotools.grid_factory import (
+    ease2_grid_helper,
+    epsg_4326n_builder,
+    epsg_4326s_builder,
+    epsg_6931_builder,
+    epsg_6932_builder,
+)
+
+
+def test_grid_factory_registers_and_dispatches_builder() -> None:
+    """Create a grid through the builder registered for a CRS."""
+    factory = GridFactory()
+    factory.register_crs("EPSG:6931", epsg_6931_builder)
+
+    grid = factory.create("EPSG:6931", resolution="25p0km", shape=(4, 6))
+
+    assert isinstance(grid, GeographicGrid)
+    assert grid.native_crs == "EPSG:6931"
+    assert grid.resolution() == "25p0km"
+    assert grid.shape() == (6, 4)
+
+
+def test_grid_factory_rejects_unknown_crs() -> None:
+    """Reject requests for CRS builders that have not been registered."""
+    with pytest.raises(ValueError, match="No builder registered for CRS: EPSG:9999"):
+        GridFactory().create("EPSG:9999", resolution="25p0km", shape=(4, 4))
+
+
+def test_ease2_grid_helper_normalises_resolution_and_centres_grid() -> None:
+    """Convert kilometre resolution to centred projected-coordinate arrays."""
+    resolution, h_points, w_points = ease2_grid_helper("25p0km", 4, 4)
+
+    assert resolution == "25p0km"
+    np.testing.assert_allclose(h_points, [-37500.0, -12500.0, 12500.0, 37500.0])
+    np.testing.assert_allclose(w_points, [37500.0, 12500.0, -12500.0, -37500.0])
+
+
+def test_ease2_grid_helper_accepts_metres_and_rejects_bad_format() -> None:
+    """Normalise metre input and reject resolutions without an explicit unit."""
+    resolution, _, _ = ease2_grid_helper("25000m", 3, 3)
+    assert resolution == "25p0km"
+
+    with pytest.raises(ValueError, match="Invalid resolution format"):
+        ease2_grid_helper("25000", 3, 3)
+
+
+def test_wgs84_north_builder_exposes_expected_coordinates() -> None:
+    """Build a northern regular lat/lon grid without coordinate transformation."""
+    grid = epsg_4326n_builder("1p0", (4, 4))
+
+    assert grid.shape() == (4, 4)
+    np.testing.assert_allclose(grid.x()[0], [-1.5, -0.5, 0.5, 1.5])
+    np.testing.assert_allclose(grid.y()[:, 0], [86.5, 87.5, 88.5, 89.5])
+    np.testing.assert_allclose(grid.longitudes(), grid.x())
+    np.testing.assert_allclose(grid.latitudes(), grid.y())
+    assert grid.mars_area() == (89.5, -1.5, 86.5, 1.5)
+
+
+def test_wgs84_south_builder_exposes_expected_coordinates() -> None:
+    """Build a southern regular lat/lon grid with the requested shape."""
+    grid = epsg_4326s_builder("1p0", (4, 4))
+
+    np.testing.assert_allclose(grid.y()[:, 0], [-3.5, -2.5, -1.5, -0.5])
+    assert grid.mars_area() == (-0.5, -1.5, -3.5, 1.5)
+
+
+def test_grid_coordinate_accessors_support_dtype_conversion() -> None:
+    """Allow callers to request coordinate arrays in a different dtype."""
+    grid = epsg_4326n_builder("1p0", (2, 2))
+
+    assert grid.x(dtype=np.float32).dtype == np.float32
+    assert grid.y(dtype=np.float32).dtype == np.float32
+    assert grid.latitudes(dtype=np.float32).dtype == np.float32
+    assert grid.longitudes(dtype=np.float32).dtype == np.float32
+
+
+def test_polar_builders_set_expected_crs_and_orientation() -> None:
+    """Construct north/south EASE2 grids with matching projected coordinates."""
+    north = epsg_6931_builder("25p0km", (3, 5))
+    south = epsg_6932_builder("25p0km", (3, 5))
+
+    assert north.native_crs == "EPSG:6931"
+    assert south.native_crs == "EPSG:6932"
+    assert north.shape() == south.shape() == (5, 3)
+    np.testing.assert_allclose(north.x(), south.x())
+    np.testing.assert_allclose(north.y(), south.y())
+
+
+def test_unimplemented_earthkit_grid_methods_raise() -> None:
+    """Keep unsupported EarthKit geography methods explicit rather than silent."""
+    grid = epsg_4326n_builder("1p0", (2, 2))
+
+    for method in (grid._unique_grid_id, grid.gridspec, grid.grid_spec, grid.projection):
+        with pytest.raises(NotImplementedError):
+            method()

--- a/tests/geotools/test_grid.py
+++ b/tests/geotools/test_grid.py
@@ -94,6 +94,11 @@ def test_unimplemented_earthkit_grid_methods_raise() -> None:
     """Keep unsupported EarthKit geography methods explicit rather than silent."""
     grid = epsg_4326n_builder("1p0", (2, 2))
 
-    for method in (grid._unique_grid_id, grid.gridspec, grid.grid_spec, grid.projection):
+    for method in (
+        grid._unique_grid_id,
+        grid.gridspec,
+        grid.grid_spec,
+        grid.projection,
+    ):
         with pytest.raises(NotImplementedError):
             method()

--- a/tests/geotools/test_grid_factory.py
+++ b/tests/geotools/test_grid_factory.py
@@ -4,20 +4,24 @@ from icenet_mp.geotools import GeographicGrid, GridFactory
 from icenet_mp.geotools.grid_factory import epsg_6931_builder
 
 
-def test_grid_factory_registers_and_dispatches_builder() -> None:
-    """Create a grid through the builder registered for a CRS."""
-    factory = GridFactory()
-    factory.register_crs("EPSG:6931", epsg_6931_builder)
+class TestGridFactory:
+    """Unit tests for the GridFactory class and its grid builders."""
 
-    grid = factory.create("EPSG:6931", resolution="25p0km", shape=(4, 6))
+    def test_grid_factory_registers_and_dispatches_builder(self) -> None:
+        """Create a grid through the builder registered for a CRS."""
+        factory = GridFactory()
+        factory.register_crs("EPSG:6931", epsg_6931_builder)
 
-    assert isinstance(grid, GeographicGrid)
-    assert grid.native_crs == "EPSG:6931"
-    assert grid.resolution() == "25p0km"
-    assert grid.shape() == (6, 4)
+        grid = factory.create("EPSG:6931", resolution="25p0km", shape=(4, 6))
 
+        assert isinstance(grid, GeographicGrid)
+        assert grid.native_crs == "EPSG:6931"
+        assert grid.resolution() == "25p0km"
+        assert grid.shape() == (6, 4)
 
-def test_grid_factory_rejects_unknown_crs() -> None:
-    """Reject requests for CRS builders that have not been registered."""
-    with pytest.raises(ValueError, match="No builder registered for CRS: EPSG:9999"):
-        GridFactory().create("EPSG:9999", resolution="25p0km", shape=(4, 4))
+    def test_grid_factory_rejects_unknown_crs(self) -> None:
+        """Reject requests for CRS builders that have not been registered."""
+        with pytest.raises(
+            ValueError, match="No builder registered for CRS: EPSG:9999"
+        ):
+            GridFactory().create("EPSG:9999", resolution="25p0km", shape=(4, 4))

--- a/tests/geotools/test_grid_factory.py
+++ b/tests/geotools/test_grid_factory.py
@@ -1,0 +1,23 @@
+import pytest
+
+from icenet_mp.geotools import GeographicGrid, GridFactory
+from icenet_mp.geotools.grid_factory import epsg_6931_builder
+
+
+def test_grid_factory_registers_and_dispatches_builder() -> None:
+    """Create a grid through the builder registered for a CRS."""
+    factory = GridFactory()
+    factory.register_crs("EPSG:6931", epsg_6931_builder)
+
+    grid = factory.create("EPSG:6931", resolution="25p0km", shape=(4, 6))
+
+    assert isinstance(grid, GeographicGrid)
+    assert grid.native_crs == "EPSG:6931"
+    assert grid.resolution() == "25p0km"
+    assert grid.shape() == (6, 4)
+
+
+def test_grid_factory_rejects_unknown_crs() -> None:
+    """Reject requests for CRS builders that have not been registered."""
+    with pytest.raises(ValueError, match="No builder registered for CRS: EPSG:9999"):
+        GridFactory().create("EPSG:9999", resolution="25p0km", shape=(4, 4))

--- a/tests/geotools/test_grid_factory.py
+++ b/tests/geotools/test_grid_factory.py
@@ -1,11 +1,18 @@
+import numpy as np
 import pytest
 
 from icenet_mp.geotools import GeographicGrid, GridFactory
-from icenet_mp.geotools.grid_factory import epsg_6931_builder
+from icenet_mp.geotools.grid_factory import (
+    ease2_grid_helper,
+    epsg_4326n_builder,
+    epsg_4326s_builder,
+    epsg_6931_builder,
+    epsg_6932_builder,
+)
 
 
 class TestGridFactory:
-    """Unit tests for the GridFactory class and its grid builders."""
+    """Unit tests for the GridFactory class."""
 
     def test_grid_factory_registers_and_dispatches_builder(self) -> None:
         """Create a grid through the builder registered for a CRS."""
@@ -25,3 +32,54 @@ class TestGridFactory:
             ValueError, match="No builder registered for CRS: EPSG:9999"
         ):
             GridFactory().create("EPSG:9999", resolution="25p0km", shape=(4, 4))
+
+
+class TestEase2GridHelper:
+    """Unit tests for the ease2_grid_helper function."""
+
+    def test_normalises_resolution_and_centres_grid(self) -> None:
+        """Convert kilometre resolution to centred projected-coordinate arrays."""
+        resolution, h_points, w_points = ease2_grid_helper("25p0km", 4, 4)
+
+        assert resolution == "25p0km"
+        np.testing.assert_allclose(h_points, [-37500.0, -12500.0, 12500.0, 37500.0])
+        np.testing.assert_allclose(w_points, [37500.0, 12500.0, -12500.0, -37500.0])
+
+    def test_accepts_metres_and_rejects_bad_format(self) -> None:
+        """Normalise metre input and reject resolutions without an explicit unit."""
+        resolution, _, _ = ease2_grid_helper("25000m", 3, 3)
+        assert resolution == "25p0km"
+
+        with pytest.raises(ValueError, match="Invalid resolution format"):
+            ease2_grid_helper("25000", 3, 3)
+
+
+class TestBuilderFunctions:
+    """Unit tests for the module-level CRS builder functions."""
+
+    def test_wgs84_north_builder_exposes_expected_coordinates(self) -> None:
+        """Build a northern regular lat/lon grid without coordinate transformation."""
+        grid = epsg_4326n_builder("1p0", (4, 4))
+
+        assert grid.shape() == (4, 4)
+        np.testing.assert_allclose(grid.x()[0], [-1.5, -0.5, 0.5, 1.5])
+        np.testing.assert_allclose(grid.y()[:, 0], [86.5, 87.5, 88.5, 89.5])
+        assert grid.mars_area() == (89.5, -1.5, 86.5, 1.5)
+
+    def test_wgs84_south_builder_exposes_expected_coordinates(self) -> None:
+        """Build a southern regular lat/lon grid with the requested shape."""
+        grid = epsg_4326s_builder("1p0", (4, 4))
+
+        np.testing.assert_allclose(grid.y()[:, 0], [-3.5, -2.5, -1.5, -0.5])
+        assert grid.mars_area() == (-0.5, -1.5, -3.5, 1.5)
+
+    def test_polar_builders_set_expected_crs_and_orientation(self) -> None:
+        """Construct north/south EASE2 grids with matching projected coordinates."""
+        north = epsg_6931_builder("25p0km", (3, 5))
+        south = epsg_6932_builder("25p0km", (3, 5))
+
+        assert north.native_crs == "EPSG:6931"
+        assert south.native_crs == "EPSG:6932"
+        assert north.shape() == south.shape() == (5, 3)
+        np.testing.assert_allclose(north.x(), south.x())
+        np.testing.assert_allclose(north.y(), south.y())

--- a/tests/geotools/test_metadata.py
+++ b/tests/geotools/test_metadata.py
@@ -1,0 +1,247 @@
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from earthkit.data.core.metadata import Metadata
+
+from icenet_mp.geotools.geographic_metadata import GeographicMetadata
+from icenet_mp.geotools.grid_factory import epsg_4326n_builder
+
+NO_ARG_DELEGATING_METHODS = [
+    ("base_datetime", datetime(2020, 1, 1)),
+    ("data_format", "grib"),
+    ("datetime", {"base_time": datetime(2020, 1, 1)}),
+    ("describe_keys", ["a", "b"]),
+    ("index_keys", ["a", "b"]),
+    ("items", [("a", 1)]),
+    ("keys", ["a", "b"]),
+    ("ls_keys", ["a", "b"]),
+    ("namespaces", ["default", "mars"]),
+    ("valid_datetime", datetime(2020, 1, 2)),
+]
+
+
+class _MetadataWithoutAsNamespace:
+    """A minimal metadata double that deliberately omits as_namespace.
+
+    Every real earthkit Metadata subclass implements as_namespace (it is
+    abstract on the base class), so this exercises the local fallback branches
+    in GeographicMetadata.as_namespace that a spec'd mock can never reach.
+    """
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def keys(self) -> Iterable[str]:
+        return self._data.keys()
+
+    def get(self, key: str, default: object = None, **_kwargs: Any) -> object:
+        return self._data.get(key, default)
+
+
+class TestGeographicMetadata:
+    """Unit tests for the GeographicMetadata class."""
+
+    def test_geography_property_returns_constructor_argument(self) -> None:
+        """Geography returns the GeographicGrid passed at construction."""
+        geography = epsg_4326n_builder("1p0", (2, 2))
+        geo_metadata = GeographicMetadata(MagicMock(spec=Metadata), geography)
+
+        assert geo_metadata.geography is geography
+
+    def test_contains_delegates_to_wrapped_metadata(self) -> None:
+        """__contains__ delegates the membership check to the wrapped metadata."""
+        mock_metadata = MagicMock(spec=Metadata)
+        mock_metadata.__contains__.return_value = True
+        geo_metadata = GeographicMetadata(
+            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        assert "some_key" in geo_metadata
+        mock_metadata.__contains__.assert_called_once_with("some_key")
+
+    def test_iter_delegates_to_wrapped_metadata(self) -> None:
+        """__iter__ delegates iteration to the wrapped metadata."""
+        mock_metadata = MagicMock(spec=Metadata)
+        mock_metadata.__iter__.return_value = iter(["a", "b"])
+        geo_metadata = GeographicMetadata(
+            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        assert list(geo_metadata) == ["a", "b"]
+
+    def test_len_delegates_to_wrapped_metadata(self) -> None:
+        """__len__ delegates to the wrapped metadata."""
+        mock_metadata = MagicMock(spec=Metadata)
+        mock_metadata.__len__.return_value = 3
+        geo_metadata = GeographicMetadata(
+            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        assert len(geo_metadata) == 3
+
+    def test_repr_includes_wrapped_metadata_and_geography(self) -> None:
+        """__repr__ reports both the wrapped metadata and the geography."""
+        mock_metadata = MagicMock(spec=Metadata)
+        geography = epsg_4326n_builder("1p0", (2, 2))
+        geo_metadata = GeographicMetadata(mock_metadata, geography)
+
+        assert (
+            repr(geo_metadata) == f"GeographicMetadata({mock_metadata!r},{geography!r})"
+        )
+
+    def test_hide_internal_keys_delegates_to_wrapped_metadata(self) -> None:
+        """_hide_internal_keys() returns whatever the wrapped metadata produces."""
+        mock_metadata = MagicMock(spec=Metadata)
+        hidden = MagicMock(spec=Metadata)
+        mock_metadata._hide_internal_keys.return_value = hidden
+        geo_metadata = GeographicMetadata(
+            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        assert geo_metadata._hide_internal_keys() is hidden
+
+    @pytest.mark.parametrize(
+        ("method_name", "return_value"),
+        NO_ARG_DELEGATING_METHODS,
+        ids=[name for name, _ in NO_ARG_DELEGATING_METHODS],
+    )
+    def test_no_arg_methods_delegate_to_wrapped_metadata(
+        self, method_name: str, return_value: object
+    ) -> None:
+        """Simple no-argument accessors delegate straight to the wrapped metadata."""
+        mock_metadata = MagicMock(spec=Metadata)
+        setattr(mock_metadata, method_name, MagicMock(return_value=return_value))
+        geo_metadata = GeographicMetadata(
+            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        result = getattr(geo_metadata, method_name)()
+
+        assert result == return_value
+        getattr(mock_metadata, method_name).assert_called_once_with()
+
+    def test_dump_forwards_kwargs_to_wrapped_metadata(self) -> None:
+        """dump() forwards its keyword arguments and returns the delegate's result."""
+        mock_metadata = MagicMock(spec=Metadata)
+        mock_metadata.dump.return_value = "dump-output"
+        geo_metadata = GeographicMetadata(
+            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        assert geo_metadata.dump(depth=2) == "dump-output"
+        mock_metadata.dump.assert_called_once_with(depth=2)
+
+    def test_get_forwards_default_when_not_raising_on_missing(self) -> None:
+        """get() passes the default through to the wrapped metadata by default."""
+        mock_metadata = MagicMock(spec=Metadata)
+        mock_metadata.get.return_value = "value"
+        geo_metadata = GeographicMetadata(
+            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        assert geo_metadata.get("key", default="fallback") == "value"
+        mock_metadata.get.assert_called_once_with("key", default="fallback")
+
+    def test_get_with_raise_on_missing_does_not_forward_the_flag(self) -> None:
+        """Current behaviour: raise_on_missing is consumed locally, not forwarded.
+
+        GeographicMetadata.get() only ever omits `default` from the delegate
+        call when raise_on_missing is True; it never passes raise_on_missing
+        itself down to the wrapped metadata's get().
+        """
+        mock_metadata = MagicMock(spec=Metadata)
+        mock_metadata.get.return_value = "value"
+        geo_metadata = GeographicMetadata(
+            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        assert geo_metadata.get("key", raise_on_missing=True) == "value"
+        mock_metadata.get.assert_called_once_with("key")
+
+    def test_get_converts_result_with_astype(self) -> None:
+        """get(astype=...) converts the delegate's result to the requested type."""
+        mock_metadata = MagicMock(spec=Metadata)
+        mock_metadata.get.return_value = "42"
+        geo_metadata = GeographicMetadata(
+            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        assert geo_metadata.get("key", astype=int) == 42
+
+    def test_get_raises_value_error_when_astype_conversion_fails(self) -> None:
+        """get(astype=...) wraps a failed conversion in a ValueError."""
+        mock_metadata = MagicMock(spec=Metadata)
+        mock_metadata.get.return_value = "not-an-int"
+        geo_metadata = GeographicMetadata(
+            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        with pytest.raises(ValueError, match="Failed to convert metadata key 'key'"):
+            geo_metadata.get("key", astype=int)
+
+    def test_override_wraps_result_with_same_geography(self) -> None:
+        """override() delegates to the wrapped metadata and keeps the geography."""
+        mock_metadata = MagicMock(spec=Metadata)
+        overridden_metadata = MagicMock(spec=Metadata)
+        mock_metadata.override.return_value = overridden_metadata
+        geography = epsg_4326n_builder("1p0", (2, 2))
+        geo_metadata = GeographicMetadata(mock_metadata, geography)
+
+        result = geo_metadata.override({"key1": 1}, key2=2)
+
+        mock_metadata.override.assert_called_once_with({"key1": 1}, key2=2)
+        assert isinstance(result, GeographicMetadata)
+        assert result.metadata_ is overridden_metadata
+        assert result.geography is geography
+
+    def test_as_namespace_delegates_when_wrapped_metadata_supports_it(self) -> None:
+        """as_namespace() delegates directly when the wrapped metadata implements it."""
+        mock_metadata = MagicMock(spec=Metadata)
+        mock_metadata.as_namespace.return_value = {"foo": "bar"}
+        geo_metadata = GeographicMetadata(
+            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        assert geo_metadata.as_namespace("mars") == {"foo": "bar"}
+        mock_metadata.as_namespace.assert_called_once_with("mars")
+
+    @pytest.mark.parametrize("namespace", [None, "", "default"])
+    def test_as_namespace_falls_back_to_all_keys_for_default_namespace(
+        self, namespace: str | None
+    ) -> None:
+        """Without a delegate, the default/empty namespace returns every key/value."""
+        fake_metadata = _MetadataWithoutAsNamespace(
+            {"key1": "value1", "key2": "value2"}
+        )
+        geo_metadata = GeographicMetadata(
+            cast("Metadata", fake_metadata), epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        assert geo_metadata.as_namespace(namespace) == {
+            "key1": "value1",
+            "key2": "value2",
+        }
+
+    def test_as_namespace_returns_empty_dict_for_mars_without_delegate(self) -> None:
+        """Without a delegate, the "mars" namespace falls back to an empty dict."""
+        fake_metadata = _MetadataWithoutAsNamespace({"key1": "value1"})
+        geo_metadata = GeographicMetadata(
+            cast("Metadata", fake_metadata), epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        assert geo_metadata.as_namespace("mars") == {}
+
+    def test_as_namespace_raises_for_unsupported_namespace_without_delegate(
+        self,
+    ) -> None:
+        """Without a delegate, an unrecognised namespace raises ValueError."""
+        fake_metadata = _MetadataWithoutAsNamespace({"key1": "value1"})
+        geo_metadata = GeographicMetadata(
+            cast("Metadata", fake_metadata), epsg_4326n_builder("1p0", (2, 2))
+        )
+
+        with pytest.raises(ValueError, match="Unsupported namespace 'bogus'"):
+            geo_metadata.as_namespace("bogus")

--- a/tests/geotools/test_metadata.py
+++ b/tests/geotools/test_metadata.py
@@ -6,10 +6,10 @@ from unittest.mock import MagicMock
 import pytest
 from earthkit.data.core.metadata import Metadata
 
+from icenet_mp.geotools.geographic_grid import GeographicGrid
 from icenet_mp.geotools.geographic_metadata import GeographicMetadata
-from icenet_mp.geotools.grid_factory import epsg_4326n_builder
 
-NO_ARG_DELEGATING_METHODS = [
+DELEGATING_METHODS = [
     ("base_datetime", datetime(2020, 1, 1)),
     ("data_format", "grib"),
     ("datetime", {"base_time": datetime(2020, 1, 1)}),
@@ -23,129 +23,137 @@ NO_ARG_DELEGATING_METHODS = [
 ]
 
 
-class _MetadataWithoutAsNamespace:
+class FakeMetadata:
     """A minimal metadata double that deliberately omits as_namespace.
 
-    Every real earthkit Metadata subclass implements as_namespace (it is
-    abstract on the base class), so this exercises the local fallback branches
-    in GeographicMetadata.as_namespace that a spec'd mock can never reach.
+    Every real earthkit Metadata subclass implements as_namespace, so this tests the
+    local fallback branches in GeographicMetadata.as_namespace.
     """
 
     def __init__(self, data: dict[str, Any]) -> None:
+        """Initialise a FakeMetadata object."""
         self._data = data
 
     def keys(self) -> Iterable[str]:
+        """Return the keys in the metadata."""
         return self._data.keys()
 
     def get(self, key: str, default: object = None, **_kwargs: Any) -> object:
+        """Return the value for a key, or the default if the key is missing."""
         return self._data.get(key, default)
 
 
 class TestGeographicMetadata:
     """Unit tests for the GeographicMetadata class."""
 
-    def test_geography_property_returns_constructor_argument(self) -> None:
+    def test_geography_property_returns_constructor_argument(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """Geography returns the GeographicGrid passed at construction."""
-        geography = epsg_4326n_builder("1p0", (2, 2))
-        geo_metadata = GeographicMetadata(MagicMock(spec=Metadata), geography)
+        geo_metadata = GeographicMetadata(MagicMock(spec=Metadata), minimal_grid)
 
-        assert geo_metadata.geography is geography
+        assert geo_metadata.geography is minimal_grid
 
-    def test_contains_delegates_to_wrapped_metadata(self) -> None:
+    def test_contains_delegates_to_wrapped_metadata(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """__contains__ delegates the membership check to the wrapped metadata."""
         mock_metadata = MagicMock(spec=Metadata)
         mock_metadata.__contains__.return_value = True
-        geo_metadata = GeographicMetadata(
-            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
-        )
+        geo_metadata = GeographicMetadata(mock_metadata, minimal_grid)
 
         assert "some_key" in geo_metadata
         mock_metadata.__contains__.assert_called_once_with("some_key")
 
-    def test_iter_delegates_to_wrapped_metadata(self) -> None:
+    def test_iter_delegates_to_wrapped_metadata(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """__iter__ delegates iteration to the wrapped metadata."""
         mock_metadata = MagicMock(spec=Metadata)
         mock_metadata.__iter__.return_value = iter(["a", "b"])
-        geo_metadata = GeographicMetadata(
-            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
-        )
+        geo_metadata = GeographicMetadata(mock_metadata, minimal_grid)
 
         assert list(geo_metadata) == ["a", "b"]
 
-    def test_len_delegates_to_wrapped_metadata(self) -> None:
+    def test_len_delegates_to_wrapped_metadata(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """__len__ delegates to the wrapped metadata."""
         mock_metadata = MagicMock(spec=Metadata)
         mock_metadata.__len__.return_value = 3
-        geo_metadata = GeographicMetadata(
-            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
-        )
+        geo_metadata = GeographicMetadata(mock_metadata, minimal_grid)
 
         assert len(geo_metadata) == 3
 
-    def test_repr_includes_wrapped_metadata_and_geography(self) -> None:
+    def test_repr_includes_wrapped_metadata_and_geography(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """__repr__ reports both the wrapped metadata and the geography."""
         mock_metadata = MagicMock(spec=Metadata)
-        geography = epsg_4326n_builder("1p0", (2, 2))
-        geo_metadata = GeographicMetadata(mock_metadata, geography)
+        geo_metadata = GeographicMetadata(mock_metadata, minimal_grid)
 
         assert (
-            repr(geo_metadata) == f"GeographicMetadata({mock_metadata!r},{geography!r})"
+            repr(geo_metadata)
+            == f"GeographicMetadata({mock_metadata!r},{minimal_grid!r})"
         )
 
-    def test_hide_internal_keys_delegates_to_wrapped_metadata(self) -> None:
+    def test_hide_internal_keys_delegates_to_wrapped_metadata(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """_hide_internal_keys() returns whatever the wrapped metadata produces."""
         mock_metadata = MagicMock(spec=Metadata)
         hidden = MagicMock(spec=Metadata)
         mock_metadata._hide_internal_keys.return_value = hidden
-        geo_metadata = GeographicMetadata(
-            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
-        )
+        geo_metadata = GeographicMetadata(mock_metadata, minimal_grid)
 
         assert geo_metadata._hide_internal_keys() is hidden
 
     @pytest.mark.parametrize(
         ("method_name", "return_value"),
-        NO_ARG_DELEGATING_METHODS,
-        ids=[name for name, _ in NO_ARG_DELEGATING_METHODS],
+        DELEGATING_METHODS,
+        ids=[name for name, _ in DELEGATING_METHODS],
     )
     def test_no_arg_methods_delegate_to_wrapped_metadata(
-        self, method_name: str, return_value: object
+        self,
+        method_name: str,
+        return_value: object,
+        minimal_grid: GeographicGrid,
     ) -> None:
         """Simple no-argument accessors delegate straight to the wrapped metadata."""
         mock_metadata = MagicMock(spec=Metadata)
         setattr(mock_metadata, method_name, MagicMock(return_value=return_value))
-        geo_metadata = GeographicMetadata(
-            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
-        )
+        geo_metadata = GeographicMetadata(mock_metadata, minimal_grid)
 
         result = getattr(geo_metadata, method_name)()
 
         assert result == return_value
         getattr(mock_metadata, method_name).assert_called_once_with()
 
-    def test_dump_forwards_kwargs_to_wrapped_metadata(self) -> None:
+    def test_dump_forwards_kwargs_to_wrapped_metadata(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """dump() forwards its keyword arguments and returns the delegate's result."""
         mock_metadata = MagicMock(spec=Metadata)
         mock_metadata.dump.return_value = "dump-output"
-        geo_metadata = GeographicMetadata(
-            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
-        )
+        geo_metadata = GeographicMetadata(mock_metadata, minimal_grid)
 
         assert geo_metadata.dump(depth=2) == "dump-output"
         mock_metadata.dump.assert_called_once_with(depth=2)
 
-    def test_get_forwards_default_when_not_raising_on_missing(self) -> None:
+    def test_get_forwards_default_when_not_raising_on_missing(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """get() passes the default through to the wrapped metadata by default."""
         mock_metadata = MagicMock(spec=Metadata)
         mock_metadata.get.return_value = "value"
-        geo_metadata = GeographicMetadata(
-            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
-        )
+        geo_metadata = GeographicMetadata(mock_metadata, minimal_grid)
 
         assert geo_metadata.get("key", default="fallback") == "value"
         mock_metadata.get.assert_called_once_with("key", default="fallback")
 
-    def test_get_with_raise_on_missing_does_not_forward_the_flag(self) -> None:
+    def test_get_with_raise_on_missing_does_not_forward_the_flag(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """Current behaviour: raise_on_missing is consumed locally, not forwarded.
 
         GeographicMetadata.get() only ever omits `default` from the delegate
@@ -154,94 +162,87 @@ class TestGeographicMetadata:
         """
         mock_metadata = MagicMock(spec=Metadata)
         mock_metadata.get.return_value = "value"
-        geo_metadata = GeographicMetadata(
-            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
-        )
+        geo_metadata = GeographicMetadata(mock_metadata, minimal_grid)
 
         assert geo_metadata.get("key", raise_on_missing=True) == "value"
         mock_metadata.get.assert_called_once_with("key")
 
-    def test_get_converts_result_with_astype(self) -> None:
+    def test_get_converts_result_with_astype(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """get(astype=...) converts the delegate's result to the requested type."""
         mock_metadata = MagicMock(spec=Metadata)
         mock_metadata.get.return_value = "42"
-        geo_metadata = GeographicMetadata(
-            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
-        )
+        geo_metadata = GeographicMetadata(mock_metadata, minimal_grid)
 
         assert geo_metadata.get("key", astype=int) == 42
 
-    def test_get_raises_value_error_when_astype_conversion_fails(self) -> None:
+    def test_get_raises_value_error_when_astype_conversion_fails(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """get(astype=...) wraps a failed conversion in a ValueError."""
         mock_metadata = MagicMock(spec=Metadata)
         mock_metadata.get.return_value = "not-an-int"
-        geo_metadata = GeographicMetadata(
-            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
-        )
+        geo_metadata = GeographicMetadata(mock_metadata, minimal_grid)
 
         with pytest.raises(ValueError, match="Failed to convert metadata key 'key'"):
             geo_metadata.get("key", astype=int)
 
-    def test_override_wraps_result_with_same_geography(self) -> None:
+    def test_override_wraps_result_with_same_geography(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """override() delegates to the wrapped metadata and keeps the geography."""
         mock_metadata = MagicMock(spec=Metadata)
         overridden_metadata = MagicMock(spec=Metadata)
         mock_metadata.override.return_value = overridden_metadata
-        geography = epsg_4326n_builder("1p0", (2, 2))
-        geo_metadata = GeographicMetadata(mock_metadata, geography)
+        geo_metadata = GeographicMetadata(mock_metadata, minimal_grid)
 
         result = geo_metadata.override({"key1": 1}, key2=2)
 
         mock_metadata.override.assert_called_once_with({"key1": 1}, key2=2)
         assert isinstance(result, GeographicMetadata)
         assert result.metadata_ is overridden_metadata
-        assert result.geography is geography
+        assert result.geography is minimal_grid
 
-    def test_as_namespace_delegates_when_wrapped_metadata_supports_it(self) -> None:
+    def test_as_namespace_delegates_when_wrapped_metadata_supports_it(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """as_namespace() delegates directly when the wrapped metadata implements it."""
         mock_metadata = MagicMock(spec=Metadata)
         mock_metadata.as_namespace.return_value = {"foo": "bar"}
-        geo_metadata = GeographicMetadata(
-            mock_metadata, epsg_4326n_builder("1p0", (2, 2))
-        )
+        geo_metadata = GeographicMetadata(mock_metadata, minimal_grid)
 
         assert geo_metadata.as_namespace("mars") == {"foo": "bar"}
         mock_metadata.as_namespace.assert_called_once_with("mars")
 
     @pytest.mark.parametrize("namespace", [None, "", "default"])
     def test_as_namespace_falls_back_to_all_keys_for_default_namespace(
-        self, namespace: str | None
+        self, namespace: str | None, minimal_grid: GeographicGrid
     ) -> None:
         """Without a delegate, the default/empty namespace returns every key/value."""
-        fake_metadata = _MetadataWithoutAsNamespace(
-            {"key1": "value1", "key2": "value2"}
-        )
-        geo_metadata = GeographicMetadata(
-            cast("Metadata", fake_metadata), epsg_4326n_builder("1p0", (2, 2))
-        )
+        fake_metadata = FakeMetadata({"key1": "value1", "key2": "value2"})
+        geo_metadata = GeographicMetadata(cast("Metadata", fake_metadata), minimal_grid)
 
         assert geo_metadata.as_namespace(namespace) == {
             "key1": "value1",
             "key2": "value2",
         }
 
-    def test_as_namespace_returns_empty_dict_for_mars_without_delegate(self) -> None:
+    def test_as_namespace_returns_empty_dict_for_mars_without_delegate(
+        self, minimal_grid: GeographicGrid
+    ) -> None:
         """Without a delegate, the "mars" namespace falls back to an empty dict."""
-        fake_metadata = _MetadataWithoutAsNamespace({"key1": "value1"})
-        geo_metadata = GeographicMetadata(
-            cast("Metadata", fake_metadata), epsg_4326n_builder("1p0", (2, 2))
-        )
+        fake_metadata = FakeMetadata({"key1": "value1"})
+        geo_metadata = GeographicMetadata(cast("Metadata", fake_metadata), minimal_grid)
 
         assert geo_metadata.as_namespace("mars") == {}
 
     def test_as_namespace_raises_for_unsupported_namespace_without_delegate(
-        self,
+        self, minimal_grid: GeographicGrid
     ) -> None:
         """Without a delegate, an unrecognised namespace raises ValueError."""
-        fake_metadata = _MetadataWithoutAsNamespace({"key1": "value1"})
-        geo_metadata = GeographicMetadata(
-            cast("Metadata", fake_metadata), epsg_4326n_builder("1p0", (2, 2))
-        )
+        fake_metadata = FakeMetadata({"key1": "value1"})
+        geo_metadata = GeographicMetadata(cast("Metadata", fake_metadata), minimal_grid)
 
         with pytest.raises(ValueError, match="Unsupported namespace 'bogus'"):
             geo_metadata.as_namespace("bogus")

--- a/tests/geotools/test_reproject.py
+++ b/tests/geotools/test_reproject.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+from icenet_mp.geotools.reproject import nearest_neighbour_indices
+
+
+class TestNearestNeighbourIndices:
+    """Unit tests for the nearest_neighbour_indices function."""
+
+    def test_raises_value_error_for_wrong_input_ndim(self) -> None:
+        """Reject an input lat/lon array that is not 3-dimensional."""
+        input_latlons = np.zeros((2, 2), dtype=np.float32)
+        output_latlons = np.zeros((1, 1, 2), dtype=np.float32)
+
+        with pytest.raises(ValueError, match="Input lat/lons must have shape"):
+            nearest_neighbour_indices(input_latlons, output_latlons)
+
+    def test_raises_value_error_for_wrong_input_last_dimension(self) -> None:
+        """Reject an input lat/lon array whose last dimension is not size 2."""
+        input_latlons = np.zeros((2, 2, 3), dtype=np.float32)
+        output_latlons = np.zeros((1, 1, 2), dtype=np.float32)
+
+        with pytest.raises(ValueError, match="Input lat/lons must have shape"):
+            nearest_neighbour_indices(input_latlons, output_latlons)
+
+    def test_raises_value_error_for_wrong_output_ndim(self) -> None:
+        """Reject an output lat/lon array that is not 3-dimensional."""
+        input_latlons = np.zeros((2, 2, 2), dtype=np.float32)
+        output_latlons = np.zeros((1, 2), dtype=np.float32)
+
+        with pytest.raises(ValueError, match="Output lat/lons must have shape"):
+            nearest_neighbour_indices(input_latlons, output_latlons)
+
+    def test_raises_value_error_for_wrong_output_last_dimension(self) -> None:
+        """Reject an output lat/lon array whose last dimension is not size 2."""
+        input_latlons = np.zeros((2, 2, 2), dtype=np.float32)
+        output_latlons = np.zeros((1, 1, 3), dtype=np.float32)
+
+        with pytest.raises(ValueError, match="Output lat/lons must have shape"):
+            nearest_neighbour_indices(input_latlons, output_latlons)
+
+    def test_finds_correct_nearest_input_cell_for_each_output_point(self) -> None:
+        """Each output point maps to the (h, w) index of its closest input cell."""
+        input_latlons = np.array(
+            [
+                [[0.0, 0.0], [0.0, 10.0]],
+                [[10.0, 0.0], [10.0, 10.0]],
+            ],
+            dtype=np.float32,
+        )
+        output_latlons = np.array(
+            [[[0.5, 0.5], [9.5, 9.6]]],
+            dtype=np.float32,
+        )
+
+        nn_indices_h, nn_indices_w = nearest_neighbour_indices(
+            input_latlons, output_latlons
+        )
+
+        assert nn_indices_h.shape == (1, 2)
+        assert nn_indices_w.shape == (1, 2)
+        np.testing.assert_array_equal(nn_indices_h, [[0, 1]])
+        np.testing.assert_array_equal(nn_indices_w, [[0, 1]])


### PR DESCRIPTION
## Summary

Adds focused unit coverage for the currently untested geotools grid/factory core.

Coverage includes:

- CRS builder registration and dispatch through `GridFactory`
- rejection of unknown CRS values
- EASE2 resolution normalisation and centred projected coordinates
- metre and kilometre resolution inputs
- invalid resolution formats
- WGS84 north/south coordinate construction
- latitude/longitude and bounding-area behaviour
- coordinate dtype conversion
- EASE2 north/south CRS construction
- explicit `NotImplementedError` behaviour for unsupported EarthKit grid methods

The tests are deterministic and offline and do not run network ingestion or large reprojection jobs.

## Testing

Full repository CI will run when the PR is opened.

Part of #62.