### PR TITLE
Document manual SIPN submission requirements

### DIFF
--- a/docs/src/how-to/submit-sipn.md
+++ b/docs/src/how-to/submit-sipn.md
@@ -1,8 +1,21 @@
 # Submit forecasts to SIPN
 
-This guide records the information needed for a first, manual submission of an IceNet-MP forecast to the Sea Ice Prediction Network (SIPN) or SIPN South.
+This guide records the requirements for a first manual IceNet-MP submission to the Sea Ice Prediction Network (SIPN) or SIPN South. Submission protocols change between seasons, so check the current call before generating files.
 
-Submission protocols change between seasons. Before generating a forecast, check the current call and treat the requirements below as a reproducible checklist rather than a replacement for the organisers' instructions.
+## Requirements at a glance
+
+| Programme | Forecast window | Main IceNet-MP-compatible outputs | Grid and metadata |
+| --- | --- | --- | --- |
+| 2026 Sea Ice Outlook | September 2026 | September mean extent; optionally daily sea-ice concentration or derived SIP/IFD/IAD fields | Extent follows the NSIDC >15% definition. The public full-field instructions do not prescribe one common grid or complete NetCDF schema. |
+| SIPN South 2025-2026 | 1 December 2025 to 28 February 2026, 90 daily steps | Total area, regional area, and sea-ice concentration | No common grid is specified; concentration files include `longitude`, `latitude`, `sftof`, and `areacello`. |
+
+The 2026 SIO solicitation lists the September deadline as **14 September 2026**. The latest published SIPN South protocol is still the 2025-2026 call; update its dates and filenames when the 2026-2027 call is published.
+
+## Check the forecast horizon
+
+The tracked daily SIC prediction configs in `icenet_mp/config/predict/` currently provide 2-, 14-, and 21-day forecast horizons. A complete September forecast requires the whole month, and SIPN South requires 90 daily steps.
+
+Before preparing a submission, agree how the selected checkpoint will cover the required window. Use a checkpoint/configuration trained and validated for that horizon, or document and validate an agreed rollout strategy. Do not silently reinitialise with observations after the call's information cutoff, because that changes the forecast being submitted.
 
 ## Choose the forecast run
 
@@ -10,45 +23,48 @@ Use the best current model agreed by the project and record enough information t
 
 - checkpoint path or identifier;
 - IceNet-MP git commit;
-- configuration used for inference;
+- inference configuration;
 - forecast initialisation date and input-data cutoff;
-- ensemble method and number of members, if applicable;
+- forecast horizon and any rollout/reinitialisation strategy;
+- ensemble method and member count, if applicable;
 - native grid, coordinate reference information, and land/ocean mask;
-- units and missing-value convention for each submitted field.
+- units and missing-value convention for each field.
 
-Keep the unmodified model output as well as the final submission files.
+Keep the unmodified model output together with the final submission files.
 
 ## Arctic Sea Ice Outlook
 
-The current [2026 Sea Ice Outlook call](https://www.seaiceprediction.org/sea-ice-outlook/august-2026-call-for-contributions) requests September monthly mean sea-ice extent and optionally full spatial forecast fields. The remaining September 2026 contribution deadline is **14 September 2026**.
+The [2026 Sea Ice Outlook solicitation](https://www.seaiceprediction.org/sea-ice-outlook/august-2026-call-for-contributions) requests September monthly mean sea-ice extent and optionally full spatial forecast fields. It also solicits optional pan-Arctic extent-anomaly forecasts; those are outside this first manual workflow.
 
 ### Sea-ice extent
 
-For consistency with the NSIDC Sea Ice Index definition used by the call:
+To match the NSIDC Sea Ice Index definition used by the call:
 
 1. For each day, sum the areas of grid cells whose sea-ice concentration exceeds 15%.
-2. Average those daily extent values over September to obtain the September monthly mean extent.
+2. Average the daily extent values over September to obtain the September monthly mean extent.
 
-The call accepts pan-Arctic and pan-Antarctic extent forecasts and an Alaska regional forecast covering the Bering, Chukchi, and Beaufort seas. The Alaska request references the NSIDC 25 km polar-stereographic regional mask; if a different regional definition is used, document it in the submission.
+The call accepts pan-Arctic and pan-Antarctic extent forecasts and an Alaska regional forecast covering the Bering, Chukchi, and Beaufort seas. The Alaska request references the NSIDC 25 km polar-stereographic regional mask. If a different regional definition is used, document it in the submission.
 
 ### Full spatial fields
 
-The call requests the following full-field diagnostics:
+The call requests:
 
 - Sea Ice Probability (SIP), the fraction of ensemble members with September sea-ice concentration above 15%;
 - Ice-Free Date (IFD), the first date concentration falls below 15%, with an optional 80% threshold;
-- Ice Advance Date (IAD) for August and September, the first freeze-up date concentration rises above 15%, with an optional 80% threshold;
+- Ice Advance Date (IAD) for August and September, reported as day of year, when freeze-up concentration first rises above 15%, with an optional 80% threshold;
 - spatial initial-condition fields, particularly sea-ice concentration and sea-ice thickness, with the initialisation date recorded.
 
-Daily sea-ice concentration fields can be submitted instead of pre-computed SIP, IFD, and IAD fields; the organisers state that they can derive those metrics from daily concentration.
+Daily sea-ice concentration fields can be submitted instead of pre-computed SIP, IFD, and IAD fields; the organisers state that they can derive those metrics from daily concentration. For a single deterministic forecast, retaining and submitting daily concentration also avoids presenting a one-member binary field as an ensemble probability.
 
-The public 2026 call does not prescribe a common grid or a complete NetCDF schema for full-field uploads. Preserve the model's geospatial information and confirm the current file-format and forecast-horizon expectations with the SIPN team before uploading. Existing contributors upload full fields to the SIPN data server; new contributors should request access using the contact in the current call.
+The public 2026 call does not prescribe a common grid or complete NetCDF schema for full-field uploads. Preserve the model's geospatial metadata and confirm the current file-format and horizon expectations with the SIO team before upload. Existing contributors use the SIPN data server; new contributors can request access from the contact named in the current call.
 
 ## SIPN South
 
-The latest published [SIPN South call](https://fmassonn.github.io/sipn-south.github.io/call-contributions.html) is for the 2025-2026 season. Use it as a planning baseline until the 2026-2027 call is published, then update dates and filenames to match the new call.
+The latest published [SIPN South call](https://fmassonn.github.io/sipn-south.github.io/call-contributions/) is for the 2025-2026 season. It requests **90 daily timesteps from 1 December 2025 through 28 February 2026**.
 
-The 2025-2026 protocol requests forecasts for **90 daily timesteps from 1 December 2025 through 28 February 2026**. The diagnostics most directly relevant to IceNet-MP are listed below in priority order.
+SIPN South requests sea-ice **area**, while SIO requests sea-ice **extent**. Keep those calculations separate. Area is concentration-weighted ocean surface; extent counts qualifying grid cells at their full area. Record the concentration threshold, ocean mask, and cell-area convention used to derive submitted area values.
+
+The SIPN South call also accepts grid-cell thickness (`sivol`) and long forecasts as low-priority diagnostics. They are outside this first SIC-focused workflow: the tracked SIC configs do not produce sea-ice thickness, and their current horizons are much shorter than the six-month minimum requested for the long-forecast diagnostic.
 
 ### Circumpolar sea-ice area
 
@@ -56,60 +72,59 @@ Submit one text file containing one row of 90 comma-separated daily Antarctic se
 
 - Units are 10^6 km².
 - Values use four decimal places, including trailing zeroes.
-- The 2025-2026 filename pattern is `<group-name>_<forecast-id>_20251201-20260228_total-area.txt`.
+- The 2025-2026 filename is `<group-name>_<forecast-id>_20251201-20260228_total-area.txt`.
 - Ensemble forecasts use one file per member and increment the three-digit forecast ID.
 
 ### Regional sea-ice area
 
 Submit one text file containing 36 rows, each with 90 comma-separated daily values using the same units and precision as the circumpolar file.
 
-Each row represents a 10° longitude bin, from `0° <= longitude < 10°` through `350° <= longitude < 360°`.
+Rows represent successive 10° longitude bins from `0° <= longitude < 10°` through `350° <= longitude < 360°`.
 
-The 2025-2026 filename pattern is `<group-name>_<forecast-id>_20251201-20260228_regional-area.txt`.
+The 2025-2026 filename is `<group-name>_<forecast-id>_20251201-20260228_regional-area.txt`.
 
 ### Sea-ice concentration
 
-Submit one NetCDF file with 90 daily timesteps. The protocol requires CMIP6-style conventions and the following variables:
+Submit one NetCDF file with 90 daily timesteps. The protocol requires CMIP6-style conventions and these variables:
 
 | Variable | Meaning | Units |
 | --- | --- | --- |
-| `siconc` | Fraction of each grid cell covered by sea ice | % |
+| `siconc` | Sea-ice concentration | % |
 | `longitude` | Grid-cell longitude | degrees east |
 | `latitude` | Grid-cell latitude | degrees north |
-| `sftof` | Fraction of each grid cell covered by ocean | % |
+| `sftof` | Ocean fraction of each grid cell | % |
 | `areacello` | Grid-cell area | m² |
 
-The 2025-2026 filename pattern is `<group-name>_<forecast-id>_20251201-20260228_concentration.nc`.
+The 2025-2026 filename is `<group-name>_<forecast-id>_20251201-20260228_concentration.nc`.
 
-The protocol does not require a single common spatial grid for concentration fields, but it does require longitude, latitude, ocean fraction, and cell area to accompany the forecast. Do not discard those fields during conversion from IceNet-MP output.
-
-For ensembles, keep one submission file per member and increment the forecast ID.
+The protocol does not specify a mandatory common spatial grid for concentration submissions. Keep the forecast on its documented contributor grid and include longitude, latitude, ocean fraction, and cell area. For ensembles, use one file per member and increment the forecast ID.
 
 ## Validate the files
 
-Before submission, check all of the following:
+Before submission, check that:
 
-- the forecast uses the intended checkpoint and configuration;
+- the intended checkpoint, commit, and configuration are recorded;
 - the first and last forecast dates match the current call;
-- the number of daily timesteps is correct;
-- sea-ice concentration units match the protocol, especially `%` for SIPN South `siconc`;
+- the forecast contains every required daily timestep without gaps or duplicate dates;
+- the forecast does not use observations beyond the permitted information cutoff;
+- concentration units match the protocol, especially `%` for SIPN South `siconc`;
 - longitude, latitude, ocean fraction, and cell area align with the forecast grid;
 - land and missing values are handled consistently;
-- scalar area or extent diagnostics can be reproduced from the submitted spatial fields;
+- area or extent diagnostics reproduce from the archived spatial fields and recorded conventions;
 - every ensemble member has a unique forecast identifier;
 - filenames use the current season's required dates and naming convention.
 
-Keep a small submission record containing the checkpoint identifier, git commit, configuration, initialisation date, input-data cutoff, generated filenames, and submission date.
+Keep a submission record containing the checkpoint identifier, git commit, configuration, initialisation date, input-data cutoff, forecast horizon, generated filenames, and submission date.
 
 ## Submit manually
 
-For the first implementation, keep submission manual:
+For the first implementation:
 
 1. Generate the required forecast from the selected current model.
-2. Convert the output into the current call's required scalar and/or spatial formats.
+2. Convert the output into the current call's scalar and/or spatial formats.
 3. Run the validation checklist above.
 4. Archive the exact files being submitted in shared project storage.
 5. Submit through the route specified by the current call.
-6. Record the submission date and the forecast identifiers used.
+6. Record the submission date and forecast identifiers.
 
 For Arctic SIO full fields, use the SIPN data-server process described in the current call. For SIPN South, the latest protocol asks contributors to place the files in a URL-accessible archive, provide that URL through the submission form, and notify the organiser after submission.

--- a/docs/src/how-to/submit-sipn.md
+++ b/docs/src/how-to/submit-sipn.md
@@ -1,0 +1,115 @@
+# Submit forecasts to SIPN
+
+This guide records the information needed for a first, manual submission of an IceNet-MP forecast to the Sea Ice Prediction Network (SIPN) or SIPN South.
+
+Submission protocols change between seasons. Before generating a forecast, check the current call and treat the requirements below as a reproducible checklist rather than a replacement for the organisers' instructions.
+
+## Choose the forecast run
+
+Use the best current model agreed by the project and record enough information to reproduce the submitted forecast:
+
+- checkpoint path or identifier;
+- IceNet-MP git commit;
+- configuration used for inference;
+- forecast initialisation date and input-data cutoff;
+- ensemble method and number of members, if applicable;
+- native grid, coordinate reference information, and land/ocean mask;
+- units and missing-value convention for each submitted field.
+
+Keep the unmodified model output as well as the final submission files.
+
+## Arctic Sea Ice Outlook
+
+The current [2026 Sea Ice Outlook call](https://www.seaiceprediction.org/sea-ice-outlook/august-2026-call-for-contributions) requests September monthly mean sea-ice extent and optionally full spatial forecast fields. The remaining September 2026 contribution deadline is **14 September 2026**.
+
+### Sea-ice extent
+
+For consistency with the NSIDC Sea Ice Index definition used by the call:
+
+1. For each day, sum the areas of grid cells whose sea-ice concentration exceeds 15%.
+2. Average those daily extent values over September to obtain the September monthly mean extent.
+
+The call accepts pan-Arctic and pan-Antarctic extent forecasts and an Alaska regional forecast covering the Bering, Chukchi, and Beaufort seas. The Alaska request references the NSIDC 25 km polar-stereographic regional mask; if a different regional definition is used, document it in the submission.
+
+### Full spatial fields
+
+The call requests the following full-field diagnostics:
+
+- Sea Ice Probability (SIP), the fraction of ensemble members with September sea-ice concentration above 15%;
+- Ice-Free Date (IFD), the first date concentration falls below 15%, with an optional 80% threshold;
+- Ice Advance Date (IAD) for August and September, the first freeze-up date concentration rises above 15%, with an optional 80% threshold;
+- spatial initial-condition fields, particularly sea-ice concentration and sea-ice thickness, with the initialisation date recorded.
+
+Daily sea-ice concentration fields can be submitted instead of pre-computed SIP, IFD, and IAD fields; the organisers state that they can derive those metrics from daily concentration.
+
+The public 2026 call does not prescribe a common grid or a complete NetCDF schema for full-field uploads. Preserve the model's geospatial information and confirm the current file-format and forecast-horizon expectations with the SIPN team before uploading. Existing contributors upload full fields to the SIPN data server; new contributors should request access using the contact in the current call.
+
+## SIPN South
+
+The latest published [SIPN South call](https://fmassonn.github.io/sipn-south.github.io/call-contributions.html) is for the 2025-2026 season. Use it as a planning baseline until the 2026-2027 call is published, then update dates and filenames to match the new call.
+
+The 2025-2026 protocol requests forecasts for **90 daily timesteps from 1 December 2025 through 28 February 2026**. The diagnostics most directly relevant to IceNet-MP are listed below in priority order.
+
+### Circumpolar sea-ice area
+
+Submit one text file containing one row of 90 comma-separated daily Antarctic sea-ice area values.
+
+- Units are 10^6 km².
+- Values use four decimal places, including trailing zeroes.
+- The 2025-2026 filename pattern is `<group-name>_<forecast-id>_20251201-20260228_total-area.txt`.
+- Ensemble forecasts use one file per member and increment the three-digit forecast ID.
+
+### Regional sea-ice area
+
+Submit one text file containing 36 rows, each with 90 comma-separated daily values using the same units and precision as the circumpolar file.
+
+Each row represents a 10° longitude bin, from `0° <= longitude < 10°` through `350° <= longitude < 360°`.
+
+The 2025-2026 filename pattern is `<group-name>_<forecast-id>_20251201-20260228_regional-area.txt`.
+
+### Sea-ice concentration
+
+Submit one NetCDF file with 90 daily timesteps. The protocol requires CMIP6-style conventions and the following variables:
+
+| Variable | Meaning | Units |
+| --- | --- | --- |
+| `siconc` | Fraction of each grid cell covered by sea ice | % |
+| `longitude` | Grid-cell longitude | degrees east |
+| `latitude` | Grid-cell latitude | degrees north |
+| `sftof` | Fraction of each grid cell covered by ocean | % |
+| `areacello` | Grid-cell area | m² |
+
+The 2025-2026 filename pattern is `<group-name>_<forecast-id>_20251201-20260228_concentration.nc`.
+
+The protocol does not require a single common spatial grid for concentration fields, but it does require longitude, latitude, ocean fraction, and cell area to accompany the forecast. Do not discard those fields during conversion from IceNet-MP output.
+
+For ensembles, keep one submission file per member and increment the forecast ID.
+
+## Validate the files
+
+Before submission, check all of the following:
+
+- the forecast uses the intended checkpoint and configuration;
+- the first and last forecast dates match the current call;
+- the number of daily timesteps is correct;
+- sea-ice concentration units match the protocol, especially `%` for SIPN South `siconc`;
+- longitude, latitude, ocean fraction, and cell area align with the forecast grid;
+- land and missing values are handled consistently;
+- scalar area or extent diagnostics can be reproduced from the submitted spatial fields;
+- every ensemble member has a unique forecast identifier;
+- filenames use the current season's required dates and naming convention.
+
+Keep a small submission record containing the checkpoint identifier, git commit, configuration, initialisation date, input-data cutoff, generated filenames, and submission date.
+
+## Submit manually
+
+For the first implementation, keep submission manual:
+
+1. Generate the required forecast from the selected current model.
+2. Convert the output into the current call's required scalar and/or spatial formats.
+3. Run the validation checklist above.
+4. Archive the exact files being submitted in shared project storage.
+5. Submit through the route specified by the current call.
+6. Record the submission date and the forecast identifiers used.
+
+For Arctic SIO full fields, use the SIPN data-server process described in the current call. For SIPN South, the latest protocol asks contributors to place the files in a URL-accessible archive, provide that URL through the submission form, and notify the organiser after submission.

--- a/docs/src/how-to/submit-sipn.md
+++ b/docs/src/how-to/submit-sipn.md
@@ -9,7 +9,7 @@ This guide records the requirements for a first manual IceNet-MP submission to t
 | 2026 Sea Ice Outlook | September 2026 | September mean extent; optionally daily sea-ice concentration or derived SIP/IFD/IAD fields | Extent follows the NSIDC >15% definition. The public full-field instructions do not prescribe one common grid or complete NetCDF schema. |
 | SIPN South 2025-2026 | 1 December 2025 to 28 February 2026, 90 daily steps | Total area, regional area, and sea-ice concentration | No common grid is specified; concentration files include `longitude`, `latitude`, `sftof`, and `areacello`. |
 
-The 2026 SIO solicitation lists the September deadline as **14 September 2026**. The latest published SIPN South protocol is still the 2025-2026 call; update its dates and filenames when the 2026-2027 call is published.
+The remaining 2026 SIO schedule lists the September deadline as **14 September 2026** and states that the September Outlook is based on May-August data. Do not use September observations in the September submission. The latest published SIPN South protocol is still the 2025-2026 call; update its dates and filenames when the 2026-2027 call is published.
 
 ## Check the forecast horizon
 
@@ -35,6 +35,17 @@ Keep the unmodified model output together with the final submission files.
 ## Arctic Sea Ice Outlook
 
 The [2026 Sea Ice Outlook solicitation](https://www.seaiceprediction.org/sea-ice-outlook/august-2026-call-for-contributions) requests September monthly mean sea-ice extent and optionally full spatial forecast fields. It also solicits optional pan-Arctic extent-anomaly forecasts; those are outside this first manual workflow.
+
+### Core Outlook submission
+
+A first manual SIO contribution does not require a full-field upload. Use the submission form linked from the relevant monthly call for the core Outlook package. For the pan-Arctic contribution, prepare:
+
+- the September monthly mean sea-ice extent forecast;
+- the forecasting method/model description;
+- uncertainty or probability information, where scientifically justified;
+- a plain-language executive summary describing the Outlook, contributing factors, and methodology.
+
+Pan-Antarctic and Alaska regional extent forecasts are optional additions. Full spatial fields use the separate SIPN data-server route described below. The solicitation states that a new Outlook must be submitted for each month; earlier monthly Outlooks are not carried forward automatically.
 
 ### Sea-ice extent
 
@@ -62,7 +73,7 @@ The public 2026 call does not prescribe a common grid or complete NetCDF schema 
 
 The latest published [SIPN South call](https://fmassonn.github.io/sipn-south.github.io/call-contributions/) is for the 2025-2026 season. It requests **90 daily timesteps from 1 December 2025 through 28 February 2026**.
 
-SIPN South requests sea-ice **area**, while SIO requests sea-ice **extent**. Keep those calculations separate. Area is concentration-weighted ocean surface; extent counts qualifying grid cells at their full area. Record the concentration threshold, ocean mask, and cell-area convention used to derive submitted area values.
+SIPN South requests sea-ice **area**, while SIO requests sea-ice **extent**. Keep those calculations separate. Area is concentration-weighted ocean surface; extent counts qualifying grid cells at their full area. The published SIPN South call does not specify the SIO 15% extent threshold for its area diagnostic, so do not reuse that threshold automatically. Record the concentration treatment, ocean mask, and cell-area convention used to derive submitted area values.
 
 The SIPN South call also accepts grid-cell thickness (`sivol`) and long forecasts as low-priority diagnostics. They are outside this first SIC-focused workflow: the tracked SIC configs do not produce sea-ice thickness, and their current horizons are much shorter than the six-month minimum requested for the long-forecast diagnostic.
 
@@ -106,7 +117,7 @@ Before submission, check that:
 - the intended checkpoint, commit, and configuration are recorded;
 - the first and last forecast dates match the current call;
 - the forecast contains every required daily timestep without gaps or duplicate dates;
-- the forecast does not use observations beyond the permitted information cutoff;
+- the forecast does not use observations beyond the permitted information cutoff; for the September 2026 SIO, this means no September observations;
 - concentration units match the protocol, especially `%` for SIPN South `siconc`;
 - longitude, latitude, ocean fraction, and cell area align with the forecast grid;
 - land and missing values are handled consistently;

--- a/zensical.toml
+++ b/zensical.toml
@@ -21,6 +21,7 @@ nav = [
         { "Train a model" = "how-to/train.md" },
         { "Train a model in multiple stages" = "how-to/train-multistage.md" },
         { "Evaluate a model" = "how-to/evaluate.md" },
+        { "Submit forecasts to SIPN" = "how-to/submit-sipn.md" },
         { "Run a hyperparameter sweep" = "how-to/sweeps.md" },
         { "Create a release" = "how-to/release.md" },
     ] },


### PR DESCRIPTION
## Summary

- document the current manual submission requirements for the 2026 Sea Ice Outlook and the latest published SIPN South protocol
- capture the requested outputs, units, spatial metadata, forecast windows, filenames, and submission routes
- distinguish the required SIO core Outlook package from the optional full-field data-server upload
- distinguish SIO sea-ice extent from SIPN South sea-ice area, including the different treatment of the 15% extent threshold
- record the September SIO information window and the current IceNet-MP horizon gap: tracked daily SIC configs cover 2, 14, or 21 days, while a complete September forecast and SIPN South require longer windows
- add a reproducibility and pre-submission validation checklist

This follows the first-pass scope discussed in #520: understand what a valid submission requires before automating export or upload.

The guide also complements #509, which proposes NetCDF export of evaluation predictions and would provide a useful field-export path for spatial submissions.

## Scope

This is documentation only. It does not choose a model/checkpoint or claim that the current 21-day configs are sufficient for either submission. The remaining modelling decision is how to produce and validate the required longer forecast horizon without changing the call's information cutoff.

The guide focuses on IceNet-MP's SIC-relevant outputs. It explicitly notes the optional SIO extent-anomaly request and the lower-priority SIPN South thickness and six-month forecast diagnostics rather than silently omitting them.

## Validation

Requirements were checked against the current 2026 Sea Ice Outlook solicitation and the latest published SIPN South 2025-2026 call.

- `uv run --group docs zensical build`
- `uv run --group dev pre-commit run --files docs/src/how-to/submit-sipn.md zensical.toml`
- `git diff --check`
- both external protocol links return HTTP 200

The documentation build reports the same two pre-existing warnings on upstream `main` (`api/index.md` missing `config.md` and an unresolved autoref in `api/models.md`); this PR introduces no new build warnings.

Refs #520
